### PR TITLE
Add Figshare integration

### DIFF
--- a/docker-base/requirements.txt
+++ b/docker-base/requirements.txt
@@ -112,6 +112,7 @@ swagger-spec-validator==2.4.3
 text-unidecode==1.2
 toml==0.10.0
 typed-ast==1.4.0
+typing-extensions==3.7.4.1
 uritemplate==3.0.0
 urllib3==1.25.3
 vine==1.3.0

--- a/docker-base/requirements.txt
+++ b/docker-base/requirements.txt
@@ -78,7 +78,7 @@ marshmallow-enum==1.0
 marshmallow-oneofschema==1.0.3
 marshmallow-sqlalchemy==0.12.1
 mccabe==0.6.1
-numpy==1.11.3
+numpy==1.18.1
 oauth2client==4.1.3
 openapi-spec-validator==0.2.7
 packaging==19.0

--- a/react_frontend/src/components/FigshareConnectionView.tsx
+++ b/react_frontend/src/components/FigshareConnectionView.tsx
@@ -1,0 +1,68 @@
+import * as React from "react";
+import { RouteComponentProps } from "react-router";
+
+import { LeftNav } from "./LeftNav";
+
+import { TaigaApi } from "../models/api";
+import { relativePath } from "../utilities/route";
+
+interface FigshareConnectionProps extends RouteComponentProps {
+    tapi: TaigaApi;
+}
+
+interface FigshareConnectionState {
+    status: "IN PROGRESS" | "SUCCESS" | "FAILURE";
+    oauthState: string;
+    code: string;
+}
+
+function redirectHome() {
+    setTimeout(() => window.location.assign(relativePath("")), 2000);
+}
+
+export default class FigshareConnectionView extends React.Component<
+    FigshareConnectionProps,
+    FigshareConnectionState
+> {
+    constructor(props: FigshareConnectionProps) {
+        super(props);
+
+        const searchParams = new URLSearchParams(this.props.location.search);
+
+        this.state = {
+            status: "IN PROGRESS",
+            oauthState: searchParams.get("state"),
+            code: searchParams.get("code")
+        };
+    }
+
+    componentDidMount() {
+        const { oauthState, code } = this.state;
+        this.props.tapi.authorize_figshare(oauthState, code).then(
+            () => this.setState({ status: "SUCCESS" }, redirectHome),
+            () => this.setState({ status: "FAILURE" }, redirectHome)
+        );
+    }
+
+    render() {
+        const { status } = this.state;
+        let message = "";
+        if (status == "IN PROGRESS") {
+            message = "Connecting to Figshare.";
+        } else if (status == "SUCCESS") {
+            message = "Successfully connected to Figshare. Redirecting to home page.";
+        } else {
+            message = "Could not connect to Figshare. Redirecting to home page.";
+        }
+
+        return (
+            <div>
+                <LeftNav items={[]} />
+                <div id="main-content">
+                    <h1>Figshare Connection</h1>
+                    <div>{message}</div>
+                </div>
+            </div>
+        );
+    }
+}

--- a/react_frontend/src/components/Token.tsx
+++ b/react_frontend/src/components/Token.tsx
@@ -5,7 +5,7 @@ import { Col, Grid, Row, OverlayTrigger, Tooltip } from "react-bootstrap";
 import { InputGroup, FormGroup, FormControl } from "react-bootstrap";
 
 import ClipboardButton from "../utilities/r-clipboard";
-import { LeftNav } from "./LeftNav";
+import { LeftNav, MenuItem } from "./LeftNav";
 
 import { TaigaApi } from "../models/api";
 import { User } from "../models/models";
@@ -16,6 +16,7 @@ export interface TokenProps extends RouteComponentProps {
 
 export interface TokenState {
     token?: string;
+    figshareAuthUrl?: string;
 }
 
 const antiPadding = {
@@ -40,9 +41,17 @@ export class Token extends React.Component<TokenProps, TokenState> {
     }
 
     doFetch() {
-        return this.props.tapi.get_user().then((user: User) => {
+        this.props.tapi.get_user().then((user: User) => {
             this.setState({
                 token: user.token
+            })
+        }).catch((err: any) => {
+            console.log(err);
+        });
+
+        this.props.tapi.get_figshare_authorization_url().then(({figshare_auth_url}) => {
+            this.setState({
+                figshareAuthUrl: figshare_auth_url
             })
         }).catch((err: any) => {
             console.log(err);
@@ -50,7 +59,14 @@ export class Token extends React.Component<TokenProps, TokenState> {
     }
 
     render() {
-        let navItems: Array<any> = [];
+        let navItems: Array<MenuItem> = [];
+
+        if (!!this.state.figshareAuthUrl) {
+            navItems.push({
+                label: "Connect to Figshare",
+                action: () => {window.location.assign(this.state.figshareAuthUrl)}
+            })
+        }
 
         const tooltipToken = (
             <Tooltip id="token_copy_confirmation"><strong>Copied!</strong></Tooltip>

--- a/react_frontend/src/components/modals/UploadToFigshare.tsx
+++ b/react_frontend/src/components/modals/UploadToFigshare.tsx
@@ -1,0 +1,375 @@
+import * as React from "react";
+import { Link } from "react-router-dom";
+import {
+    Modal,
+    Button,
+    FormGroup,
+    FormControl,
+    FormControlProps,
+    ControlLabel,
+    Table,
+    ProgressBar
+} from "react-bootstrap";
+import update from "immutability-helper";
+
+import * as Models from "../../models/models";
+import { TaigaApi } from "../../models/api";
+import { relativePath } from "../../utilities/route";
+
+import "../../styles/modals/uploadtofigshare.css";
+type Props = {
+    tapi: TaigaApi;
+    handleClose: () => void;
+    show: boolean;
+    figshareLinked: boolean;
+    datasetVersion: Models.DatasetVersion;
+};
+
+type State = {
+    articleTitle: string;
+    articleDescription: string;
+    filesToUpload: Array<{
+        datafileId: string;
+        datafileName: string;
+        figshareFileName: string;
+        include: boolean;
+    }>;
+    uploadResults?: {
+        article_id: number;
+        files: Array<{
+            datafile_id: string;
+            file_name: string;
+            task_id?: string;
+            failure_reason?: string;
+            taskStatus?: Models.TaskStatus;
+        }>;
+    };
+};
+
+export default class UploadToFigshare extends React.Component<Props, State> {
+    datafileIdToName: Map<string, string>;
+    constructor(props: Props) {
+        super(props);
+
+        this.datafileIdToName = new Map();
+        this.populateDatafileIdToNameMap(props);
+
+        this.state = this.getDefaultStateFromProps(props);
+    }
+
+    populateDatafileIdToNameMap(props: Props) {
+        props.datasetVersion.datafiles.forEach(datafile => {
+            this.datafileIdToName.set(datafile.id, datafile.name);
+        });
+    }
+
+    getDefaultStateFromProps(props: Props): State {
+        return {
+            articleTitle: props.datasetVersion.dataset.name,
+            articleDescription: "",
+            filesToUpload: props.datasetVersion.datafiles.map(datafile => {
+                return {
+                    datafileId: datafile.id,
+                    datafileName: datafile.name,
+                    figshareFileName:
+                        datafile.type == "Raw" ? datafile.name : datafile.name + ".csv",
+                    include: true
+                };
+            }),
+            uploadResults: undefined
+        };
+    }
+
+    componentDidUpdate(prevProps: Props) {
+        if (prevProps.datasetVersion.id != this.props.datasetVersion.id) {
+            this.populateDatafileIdToNameMap(this.props);
+            this.setState(this.getDefaultStateFromProps(this.props));
+        }
+    }
+
+    handleArticleTitleChange(e: React.FormEvent<FormControlProps>) {
+        this.setState({ articleTitle: e.currentTarget.value as string });
+    }
+
+    handleArticleDescriptionChange(e: React.FormEvent<FormControlProps>) {
+        this.setState({ articleDescription: e.currentTarget.value as string });
+    }
+
+    handleFileNameChange(e: React.FormEvent<FormControlProps>, i: number) {
+        // @ts-ignore
+        this.setState({
+            filesToUpload: update(this.state.filesToUpload, {
+                [i]: { figshareFileName: { $set: e.currentTarget.value } }
+            })
+        });
+    }
+
+    toggleIncludeFile(currentVal: boolean, i: number) {
+        // @ts-ignore
+        this.setState({
+            filesToUpload: update(this.state.filesToUpload, {
+                [i]: { include: { $set: !currentVal } }
+            })
+        });
+    }
+
+    handleUploadToFigshare() {
+        this.props.tapi
+            .upload_dataset_version_to_figshare(
+                this.props.datasetVersion.id,
+                this.state.articleTitle,
+                this.state.articleDescription,
+                this.state.filesToUpload
+                    .filter(fileToUpload => fileToUpload.include)
+                    .map(fileToUpload => {
+                        return {
+                            datafile_id: fileToUpload.datafileId,
+                            file_name: fileToUpload.figshareFileName
+                        };
+                    })
+            )
+            .then(value => {
+                this.setState({ uploadResults: value });
+                value.files.forEach((file, i) => {
+                    if (file.task_id) {
+                        this.pollUploadToFigshareFile(i, file.task_id);
+                    }
+                });
+            })
+            .catch(value => {
+                console.log("failure");
+                console.log(value);
+            });
+    }
+
+    pollUploadToFigshareFile(i: number, taskId: string) {
+        this.props.tapi.get_task_status(taskId).then((newStatus: Models.TaskStatus) => {
+            this.setState(
+                // @ts-ignore
+                {
+                    uploadResults: update(this.state.uploadResults, {
+                        files: {
+                            [i]: { taskStatus: { $set: newStatus } }
+                        }
+                    })
+                },
+                () => {
+                    if (newStatus.state != "SUCCESS" && newStatus.state != "FAILURE") {
+                        setTimeout(
+                            () => this.pollUploadToFigshareFile(i, taskId),
+                            1000
+                        );
+                    }
+                }
+            );
+        });
+    }
+
+    renderUploadingStatusTable() {
+        return (
+            <Table responsive striped bsClass="table figshare-upload-files-table">
+                <thead>
+                    <tr>
+                        <th>Datafile</th>
+                        <th>Upload status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {this.state.uploadResults.files.map((file, i) => {
+                        let progressIndicator = null;
+
+                        const state = file.taskStatus ? file.taskStatus.state : null;
+                        if (file.failure_reason) {
+                            progressIndicator = (
+                                <ProgressBar
+                                    now={0}
+                                    label={`Failed to upload: ${file.failure_reason}`}
+                                    bsStyle="danger"
+                                />
+                            );
+                        } else if (state == "PROGRESS") {
+                            progressIndicator = (
+                                <ProgressBar
+                                    now={file.taskStatus.current * 100}
+                                    label="Uploading"
+                                />
+                            );
+                        } else if (state == "SUCCESS") {
+                            progressIndicator = (
+                                <ProgressBar now={100} label="Uploaded" />
+                            );
+                        } else if (state == "FAILURE") {
+                            progressIndicator = (
+                                <ProgressBar
+                                    now={file.taskStatus.current * 100}
+                                    label={"Failed to upload"}
+                                    bsStyle="danger"
+                                />
+                            );
+                        }
+
+                        return (
+                            <tr key={file.datafile_id}>
+                                <td>{this.datafileIdToName.get(file.datafile_id)}</td>
+                                <td>{progressIndicator}</td>
+                            </tr>
+                        );
+                    })}
+                </tbody>
+            </Table>
+        );
+    }
+
+    renderUploadTable() {
+        return (
+            <Table responsive striped bsClass="table figshare-upload-files-table">
+                <thead>
+                    <tr>
+                        <th>Include</th>
+                        <th>Datafile</th>
+                        <th>Figshare file name</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {this.state.filesToUpload.map((fileToUpload, i) => (
+                        <tr key={fileToUpload.datafileId}>
+                            <td>
+                                <input
+                                    type="checkbox"
+                                    checked={fileToUpload.include}
+                                    onChange={() =>
+                                        this.toggleIncludeFile(fileToUpload.include, i)
+                                    }
+                                />
+                            </td>
+                            <td>{fileToUpload.datafileName}</td>
+                            <td>
+                                <FormControl
+                                    type="text"
+                                    onChange={(
+                                        e: React.FormEvent<
+                                            FormControl & FormControlProps
+                                        >
+                                    ) => this.handleFileNameChange(e, i)}
+                                    value={this.state.filesToUpload[i].figshareFileName}
+                                />
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </Table>
+        );
+    }
+
+    renderUploadForm() {
+        const isUploading = !!this.state.uploadResults;
+        return (
+            <form>
+                <FormGroup controlId="formArticleTitle">
+                    <ControlLabel>Figshare article title</ControlLabel>
+                    <FormControl
+                        type="text"
+                        onChange={(
+                            e: React.FormEvent<FormControl & FormControlProps>
+                        ) => this.handleArticleTitleChange(e)}
+                        value={this.state.articleTitle}
+                        disabled={isUploading}
+                    />
+                </FormGroup>
+                <FormGroup controlId="formArticleDescription">
+                    <ControlLabel>Figshare article description</ControlLabel>
+                    <FormControl
+                        componentClass="textarea"
+                        onChange={(
+                            e: React.FormEvent<FormControl & FormControlProps>
+                        ) => this.handleArticleDescriptionChange(e)}
+                        value={this.state.articleDescription}
+                        bsClass="form-control textarea-lock-width"
+                        disabled={isUploading}
+                    />
+                </FormGroup>
+                {isUploading
+                    ? this.renderUploadingStatusTable()
+                    : this.renderUploadTable()}
+            </form>
+        );
+    }
+
+    renderModalBodyContent() {
+        if (!this.props.figshareLinked) {
+            return (
+                <p>
+                    You are not connected to Figshare. You can connect to Figshare via
+                    the link in the sidebar on the{" "}
+                    <Link to={relativePath("token")}>My Token</Link> page.
+                </p>
+            );
+        }
+
+        return this.renderUploadForm();
+    }
+
+    render() {
+        const uploadComplete =
+            this.state.uploadResults &&
+            this.state.uploadResults.files.every(
+                file =>
+                    !!file.failure_reason ||
+                    (file.taskStatus &&
+                        (file.taskStatus.state == "SUCCESS" ||
+                            file.taskStatus.state == "FAILURE"))
+            );
+        const uploadSuccessful =
+            uploadComplete &&
+            this.state.uploadResults.files.every(
+                file => file.taskStatus && file.taskStatus.state == "SUCCESS"
+            );
+
+        const isUploading = !!this.state.uploadResults && !uploadComplete;
+
+        let primaryAction = null;
+        if (uploadComplete) {
+            primaryAction = (
+                <Button
+                    bsStyle="success"
+                    href={`https://figshare.com/account/articles/${this.state.uploadResults.article_id}`}
+                    target="_blank"
+                >
+                    See your new Figshare article
+                </Button>
+            );
+        } else if (isUploading) {
+            primaryAction = (
+                <Button bsStyle="primary" disabled={true}>
+                    Uploading to Figshare...
+                </Button>
+            );
+        } else {
+            primaryAction = (
+                <Button
+                    onClick={() => this.handleUploadToFigshare()}
+                    bsStyle="primary"
+                    disabled={!this.props.figshareLinked}
+                >
+                    Upload to Figshare
+                </Button>
+            );
+        }
+        return (
+            <Modal
+                show={this.props.show}
+                onHide={this.props.handleClose}
+                dialogClassName="upload-to-figshare-modal"
+            >
+                <Modal.Header closeButton>
+                    <Modal.Title>Upload to Figshare</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>{this.renderModalBodyContent()}</Modal.Body>
+                <Modal.Footer>
+                    <Button onClick={this.props.handleClose}>Close</Button>
+                    {primaryAction}
+                </Modal.Footer>
+            </Modal>
+        );
+    }
+}

--- a/react_frontend/src/components/modals/UploadToFigshare.tsx
+++ b/react_frontend/src/components/modals/UploadToFigshare.tsx
@@ -19,9 +19,9 @@ import { relativePath } from "../../utilities/route";
 import "../../styles/modals/uploadtofigshare.css";
 type Props = {
     tapi: TaigaApi;
-    handleClose: () => void;
+    handleClose: (uploadComplete: boolean, figsharePrivateUrl: string) => void;
     show: boolean;
-    figshareLinked: boolean;
+    userFigshareLinked: boolean;
     datasetVersion: Models.DatasetVersion;
 };
 
@@ -296,7 +296,7 @@ export default class UploadToFigshare extends React.Component<Props, State> {
     }
 
     renderModalBodyContent() {
-        if (!this.props.figshareLinked) {
+        if (!this.props.userFigshareLinked) {
             return (
                 <p>
                     You are not connected to Figshare. You can connect to Figshare via
@@ -319,20 +319,17 @@ export default class UploadToFigshare extends React.Component<Props, State> {
                         (file.taskStatus.state == "SUCCESS" ||
                             file.taskStatus.state == "FAILURE"))
             );
-        const uploadSuccessful =
-            uploadComplete &&
-            this.state.uploadResults.files.every(
-                file => file.taskStatus && file.taskStatus.state == "SUCCESS"
-            );
 
         const isUploading = !!this.state.uploadResults && !uploadComplete;
 
         let primaryAction = null;
+        let figsharePrivateUrl: string = null
         if (uploadComplete) {
+            figsharePrivateUrl = `https://figshare.com/account/articles/${this.state.uploadResults.article_id}`;
             primaryAction = (
                 <Button
                     bsStyle="success"
-                    href={`https://figshare.com/account/articles/${this.state.uploadResults.article_id}`}
+                    href={figsharePrivateUrl}
                     target="_blank"
                 >
                     See your new Figshare article
@@ -349,7 +346,7 @@ export default class UploadToFigshare extends React.Component<Props, State> {
                 <Button
                     onClick={() => this.handleUploadToFigshare()}
                     bsStyle="primary"
-                    disabled={!this.props.figshareLinked}
+                    disabled={!this.props.userFigshareLinked}
                 >
                     Upload to Figshare
                 </Button>
@@ -358,7 +355,7 @@ export default class UploadToFigshare extends React.Component<Props, State> {
         return (
             <Modal
                 show={this.props.show}
-                onHide={this.props.handleClose}
+                onHide={() => this.props.handleClose(uploadComplete, figsharePrivateUrl)}
                 dialogClassName="upload-to-figshare-modal"
             >
                 <Modal.Header closeButton>
@@ -366,7 +363,7 @@ export default class UploadToFigshare extends React.Component<Props, State> {
                 </Modal.Header>
                 <Modal.Body>{this.renderModalBodyContent()}</Modal.Body>
                 <Modal.Footer>
-                    <Button onClick={this.props.handleClose}>Close</Button>
+                    <Button onClick={() => this.props.handleClose(uploadComplete, figsharePrivateUrl)}>Close</Button>
                     {primaryAction}
                 </Modal.Footer>
             </Modal>

--- a/react_frontend/src/index.tsx
+++ b/react_frontend/src/index.tsx
@@ -17,6 +17,8 @@ import { RecentlyViewed } from "./components/RecentlyViewed";
 import { GroupListView } from "./components/GroupListView";
 import { GroupView } from "./components/GroupView";
 
+import FigshareConnectionView from "./components/FigshareConnectionView";
+
 import { relativePath } from "./utilities/route";
 import { FormControl, Overlay, Popover, Tooltip } from "react-bootstrap";
 import { SHA } from "./version"
@@ -374,6 +376,12 @@ export function initPage(element: any) {
 						path={relativePath("group/:groupId")}
 						render={props => {
 							return <GroupView {...props} tapi={tapi} />;
+						}}
+					/>
+					<Route
+						path={relativePath("figshare/")}
+						render={props => {
+							return <FigshareConnectionView {...props} tapi={tapi} />;
 						}}
 					/>
 					<Route path="*" component={NoMatch} />

--- a/react_frontend/src/index.tsx
+++ b/react_frontend/src/index.tsx
@@ -284,7 +284,7 @@ export function initPage(element: any) {
 							)}
 							render={props => {
 								return (
-									<DatasetView {...props} tapi={tapi} />
+									<DatasetView {...props} tapi={tapi} user={user} />
 								);
 							}}
 						/>
@@ -294,7 +294,7 @@ export function initPage(element: any) {
 							)}
 							render={props => {
 								return (
-									<DatasetView {...props} tapi={tapi} />
+									<DatasetView {...props} tapi={tapi} user={user} />
 								);
 							}}
 						/>
@@ -304,7 +304,7 @@ export function initPage(element: any) {
 							)}
 							render={props => {
 								return (
-									<DatasetView {...props} tapi={tapi} />
+									<DatasetView {...props} tapi={tapi} user={user} />
 								);
 							}}
 						/>
@@ -312,7 +312,7 @@ export function initPage(element: any) {
 							path={relativePath("dataset/:datasetId")}
 							render={props => {
 								return (
-									<DatasetView {...props} tapi={tapi} />
+									<DatasetView {...props} tapi={tapi} user={user} />
 								);
 							}}
 						/>
@@ -322,7 +322,7 @@ export function initPage(element: any) {
 							"dataset_version/:datasetVersionId"
 						)}
 						render={props => {
-							return <DatasetView {...props} tapi={tapi} />;
+							return <DatasetView {...props} tapi={tapi} user={user} />;
 						}}
 					/>
 					<Route

--- a/react_frontend/src/models/api.ts
+++ b/react_frontend/src/models/api.ts
@@ -336,4 +336,34 @@ export class TaigaApi {
     authorize_figshare(state: string, code: string): Promise<{}> {
         return this._put<{}>("/figshare", {state, code})
     }
+
+    upload_dataset_version_to_figshare(
+        dataset_version_id: string,
+        article_name: string,
+        article_description: string,
+        files_to_upload: Array<{ datafile_id: string; file_name: string }>
+    ): Promise<{
+        article_id: number;
+        files: Array<{
+            datafile_id: string;
+            file_name: string;
+            failure_reason?: string;
+            task_id?: string;
+        }>;
+    }> {
+        return this._post<{
+            article_id: number;
+            files: Array<{
+                datafile_id: string;
+                file_name: string;
+                failure_reason?: string;
+                task_id?: string;
+            }>;
+        }>("/figshare/link", {
+            dataset_version_id,
+            article_name,
+            article_description,
+            files_to_upload
+        });
+    }
 }

--- a/react_frontend/src/models/api.ts
+++ b/react_frontend/src/models/api.ts
@@ -330,11 +330,11 @@ export class TaigaApi {
     }
 
     get_figshare_authorization_url(): Promise<{figshare_auth_url: string}> {
-        return this._fetch<{figshare_auth_url: string}>("/figshare/auth_url");
+        return this._fetch("/figshare/auth_url");
     }
 
     authorize_figshare(state: string, code: string): Promise<{}> {
-        return this._put<{}>("/figshare", {state, code})
+        return this._put("/figshare", {state, code})
     }
 
     upload_dataset_version_to_figshare(
@@ -351,19 +351,17 @@ export class TaigaApi {
             task_id?: string;
         }>;
     }> {
-        return this._post<{
-            article_id: number;
-            files: Array<{
-                datafile_id: string;
-                file_name: string;
-                failure_reason?: string;
-                task_id?: string;
-            }>;
-        }>("/figshare/link", {
+        return this._post("/figshare/link", {
             dataset_version_id,
             article_name,
             article_description,
             files_to_upload
         });
+    }
+
+    get_figshare_article_public_url(
+        datasetVersionId: string
+    ): Promise<{ figshare_public_url: string }> {
+        return this._fetch(`/figshare/article/${datasetVersionId}`);
     }
 }

--- a/react_frontend/src/models/api.ts
+++ b/react_frontend/src/models/api.ts
@@ -81,6 +81,22 @@ export class TaigaApi {
             })
     }
 
+    _put<T>(url: string, args: any): Promise<T> {
+        return fetch(this.baseUrl + url, {
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "Authorization": this.authHeaders.auth
+            },
+            body: JSON.stringify(args)
+        })
+            .then((response: Response) => this._checkResponse(response))
+            .then<T>((response: Response) => {
+                return response.json();
+            })
+    }
+
     get_user(): Promise<User> {
         return this._fetch<User>("/user")
     }
@@ -311,5 +327,13 @@ export class TaigaApi {
 		userIds: Array<string>
 	): Promise<Group> {
 		return this._post<Group>("/group/" + groupId + "/remove", { userIds });
-	}
+    }
+
+    get_figshare_authorization_url(): Promise<{figshare_auth_url: string}> {
+        return this._fetch<{figshare_auth_url: string}>("/figshare/auth_url");
+    }
+
+    authorize_figshare(state: string, code: string): Promise<{}> {
+        return this._put<{}>("/figshare", {state, code})
+    }
 }

--- a/react_frontend/src/models/models.ts
+++ b/react_frontend/src/models/models.ts
@@ -92,6 +92,7 @@ export interface User {
     "home_folder_id": string;
     "trash_folder_id": string;
     "token": string;
+    "figshare_linked": boolean;
 }
 
 export interface UserNamedId {
@@ -119,6 +120,7 @@ export class DatasetVersion extends Entry {
     folders: Array<NamedId>;
     can_edit: boolean;
     can_view: boolean;
+    figshare_article_id?: number;
 
     constructor(data: any, dataset: Dataset) {
         super(data);

--- a/react_frontend/src/models/models.ts
+++ b/react_frontend/src/models/models.ts
@@ -120,7 +120,7 @@ export class DatasetVersion extends Entry {
     folders: Array<NamedId>;
     can_edit: boolean;
     can_view: boolean;
-    figshare_article_id?: number;
+    figshare_linked: boolean;
 
     constructor(data: any, dataset: Dataset) {
         super(data);
@@ -151,6 +151,7 @@ export interface DatasetVersionDatafiles {
     allowed_conversion_type: Array<string>;
     short_summary: string;
     gcs_path: string;
+    figshare_linked: boolean;
 }
 
 export interface DatasetVersions {

--- a/react_frontend/src/styles/modals/uploadtofigshare.css
+++ b/react_frontend/src/styles/modals/uploadtofigshare.css
@@ -1,0 +1,11 @@
+.upload-to-figshare-modal {
+    min-width: 66%;
+}
+
+.figshare-upload-files-table > tbody > tr > td {
+    vertical-align: middle !important;
+}
+
+.textarea-lock-width {
+    resize: vertical;
+}

--- a/react_frontend/webpack.config.js
+++ b/react_frontend/webpack.config.js
@@ -27,7 +27,7 @@ module.exports = {
             { test: /\.tsx?$/, loader: "awesome-typescript-loader" },
             // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
             { enforce: "pre", test: /\.js$/, loader: "source-map-loader", exclude: ["/node_modules/"] },
-            // the following are only needed for processing css, which we (currently) only do when running cosmos
+            // the following are only needed for processing css
             { test: /\.css$/, use: ['style-loader', 'css-loader'] },
             { test: /\.(ttf|otf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?|(jpg|gif)$/, loader: 'file-loader'},
             { test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: 'url-loader?limit=10000&mimetype=application/font-woff'},

--- a/requirements.txt
+++ b/requirements.txt
@@ -115,6 +115,7 @@ swagger-spec-validator==2.4.3
 text-unidecode==1.2
 toml==0.10.0
 typed-ast==1.4.0
+typing-extensions==3.7.4.1
 uritemplate==3.0.0
 urllib3==1.25.3
 vine==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,7 @@ marshmallow-enum==1.0
 marshmallow-oneofschema==1.0.3
 marshmallow-sqlalchemy==0.12.1
 mccabe==0.6.1
-numpy==1.11.3
+numpy==1.18.1
 oauth2client==4.1.3
 openapi-spec-validator==0.2.7
 packaging==19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ Flask==1.0.3
 flask-marshmallow==0.7.0
 Flask-Migrate==2.0.3
 Flask-Script==2.0.5
+flask-shell-ipython==0.4.1
 Flask-SQLAlchemy==2.1
 freezegun==0.3.8
 future==0.16.0

--- a/settings.cfg.sample
+++ b/settings.cfg.sample
@@ -21,3 +21,7 @@ SQLALCHEMY_DATABASE_URI = 'sqlite:///db.sqlite3'
 
 # Exception to StackDriver
 REPORT_EXCEPTIONS = False
+
+# Figshare
+FIGSHARE_CLIENT_ID = ''
+FIGSHARE_CLIENT_SECRET = ''

--- a/taiga2/controllers/endpoint.py
+++ b/taiga2/controllers/endpoint.py
@@ -5,6 +5,8 @@ import sys
 import time
 import urllib
 import re
+from typing import List, Dict
+from typing_extensions import TypedDict
 
 from .endpoint_validation import validate
 
@@ -1181,3 +1183,71 @@ def add_figshare_token(figshareOAuthRequest):
             return flask.jsonify({})
     except HTTPError as error:
         return flask.abort(400)
+
+
+@validate
+def upload_dataset_version_to_figshare(figshareDatasetVersionLink):
+    dataset_version_id = figshareDatasetVersionLink["dataset_version_id"]
+    article_name = figshareDatasetVersionLink["article_name"]
+    article_description = figshareDatasetVersionLink["article_description"]
+    files_to_upload = figshareDatasetVersionLink["files_to_upload"]
+
+    figshare_authorization = (
+        models_controller.get_figshare_authorization_for_current_user()
+    )
+    if figshare_authorization is None:
+        flask.abort(401)
+
+    token, refresh_token = figshare.validate_token(
+        figshare_authorization.token, figshare_authorization.refresh_token
+    )
+    if token is None:
+        flask.abort(401)
+
+    if token != figshare_authorization.token:
+        figshare_authorization = models_controller.update_figshare_token(
+            figshare_authorization.id, token, refresh_token
+        )
+
+    dataset_version = models_controller.get_dataset_version(dataset_version_id)
+    new_article_id = figshare.create_article(
+        article_name, article_description, figshare_authorization.token
+    )
+
+    figshare_dataset_version_link = models_controller.add_figshare_dataset_version_link(
+        dataset_version_id, new_article_id
+    )
+
+    for file_to_upload in files_to_upload:
+        datafile = models_controller.get_datafile(file_to_upload["datafile_id"])
+        if datafile.type == "gcs":
+            file_to_upload["failure_reason"] = "Cannot upload GCS pointer files"
+            continue
+        elif datafile.type == "virtual":
+            datafile = datafile.underlying_data_file
+
+        if datafile.compressed_s3_key is None:
+            file_to_upload[
+                "failure_reason"
+            ] = "Cannot upload files without compressed S3 file"
+            continue
+
+        upload_successful, message_or_id = figshare.upload_datafile(
+            new_article_id,
+            file_to_upload["file_name"],
+            datafile.compressed_s3_key,
+            datafile.original_file_md5,
+            figshare_authorization.token,
+        )
+
+        if upload_successful:
+            figshare_datafile_link = models_controller.add_figshare_datafile_link(
+                file_to_upload["datafile_id"],
+                message_or_id,
+                figshare_dataset_version_link.id,
+            )
+            file_to_upload["figshare_file_id"] = figshare_datafile_link.figshare_file_id
+        else:
+            file_to_upload["failure_reason"] = message_or_id
+
+    return flask.jsonify({"article_id": new_article_id, "files": files_to_upload})

--- a/taiga2/controllers/models_controller.py
+++ b/taiga2/controllers/models_controller.py
@@ -2068,6 +2068,12 @@ def update_figshare_token(
     return figshare_authorization
 
 
+def remove_figshare_token(figshare_authorization_id: str):
+    figshare_authorization = get_figshare_authorization(figshare_authorization_id)
+    db.session.delete(figshare_authorization)
+    db.session.commit()
+
+
 def add_figshare_dataset_version_link(
     dataset_version_id: str, figshare_article_id: int
 ):

--- a/taiga2/controllers/models_controller.py
+++ b/taiga2/controllers/models_controller.py
@@ -2071,8 +2071,11 @@ def update_figshare_token(
 def add_figshare_dataset_version_link(
     dataset_version_id: str, figshare_article_id: int
 ):
+    current_user = get_current_session_user()
     figshare_dataset_version_link = FigshareDatasetVersionLink(
-        figshare_article_id=figshare_article_id, dataset_version_id=dataset_version_id
+        figshare_article_id=figshare_article_id,
+        dataset_version_id=dataset_version_id,
+        creator_id=current_user.id,
     )
 
     db.session.add(figshare_dataset_version_link)

--- a/taiga2/controllers/models_controller.py
+++ b/taiga2/controllers/models_controller.py
@@ -5,7 +5,7 @@ import uuid
 import os
 import re
 
-from typing import List, Optional
+from typing import List, Tuple, Optional
 
 import json
 
@@ -31,6 +31,7 @@ from taiga2.models import (
     NameUpdateActivity,
     DescriptionUpdateActivity,
     VersionAdditionActivity,
+    FigshareAuthorization,
 )
 from taiga2.models import UploadSession, UploadSessionFile, ConversionCache
 from taiga2.models import UserLog
@@ -2004,6 +2005,52 @@ def get_activity_for_dataset_id(dataset_id):
         # .order_by(Activity.timestamp.desc())
         .all()
     )
+
+
+def get_figshare_authorization(
+    figshare_authorization_id: str,
+) -> Optional[FigshareAuthorization]:
+    return (
+        db.session.query(FigshareAuthorization)
+        .filter(FigshareAuthorization.id == figshare_authorization_id)
+        .one_or_none()
+    )
+
+
+def get_figshare_authorization_for_user(user: User) -> Optional[FigshareAuthorization]:
+    return (
+        db.session.query(FigshareAuthorization)
+        .filter(FigshareAuthorization.user_id == user.id)
+        .one_or_none()
+    )
+
+
+def add_figshare_token(
+    figshare_account_id: int, token: str, refresh_token: str
+) -> Tuple[FigshareAuthorization, bool]:
+    current_user = get_current_session_user()
+
+    figshare_authorization = get_figshare_authorization_for_user(current_user)
+
+    if figshare_authorization is not None:
+        is_new = False
+        figshare_authorization.token = token
+        figshare_authorization.refresh_token = refresh_token
+    else:
+        is_new = True
+        figshare_authorization = FigshareAuthorization(
+            user_id=current_user.id,
+            figshare_account_id=figshare_account_id,
+            token=token,
+            refresh_token=refresh_token,
+        )
+
+    current_user.figshare_authorization_id = figshare_authorization.id
+
+    db.session.add(figshare_authorization)
+    db.session.add(current_user)
+    db.session.commit()
+    return figshare_authorization, is_new
 
 
 # </editor-fold

--- a/taiga2/figshare.py
+++ b/taiga2/figshare.py
@@ -8,12 +8,15 @@ import requests
 import shutil
 import tempfile
 from requests.exceptions import HTTPError
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, IO, Optional, Tuple, Union
 from typing_extensions import Literal, TypedDict
 
 from flask import current_app
 
+import taiga2.controllers.models_controller as mc
 from taiga2.aws import aws
+from taiga2.conv.util import Progress
+from taiga2.tasks import celery
 
 AUTH_URL = "https://figshare.com/account/applications/authorize{}"
 BASE_URL = "https://api.figshare.com/v2/{}"
@@ -60,16 +63,16 @@ def validate_token(token: str, refresh_token: str) -> Tuple[str, str]:
             return None, None
 
 
-def create_article(title: str, description: str, token: str):
+def create_article(dataset_version_id: str, title: str, description: str, token: str):
     data = {"title": title, "description": description}
     result = issue_request("POST", "account/articles", token, data=data)
 
     result = raw_issue_request("GET", result["location"], token)
 
-    return result["id"]
+    return mc.add_figshare_dataset_version_link(dataset_version_id, result["id"])
 
 
-def get_file_check_data(download_dest, compressed_s3_key: str, md5: Optional[str]):
+def get_file_check_data(download_dest: IO, compressed_s3_key: str, md5: Optional[str]):
     s3 = aws.s3
     bucket_name = current_app.config["S3_BUCKET"]
 
@@ -100,7 +103,7 @@ def initiate_new_upload(
     compressed_s3_key: str,
     md5: Optional[str],
     token: str,
-    download_dest,
+    download_dest: IO,
 ) -> Dict[str, Any]:
     endpoint = "account/articles/{}/files".format(article_id)
 
@@ -113,21 +116,23 @@ def initiate_new_upload(
     return result
 
 
-def upload_parts(download_dest, file_info, token: str):
+def upload_parts(download_dest: IO, file_info, progress: Progress, token: str):
     url = "{upload_url}".format(**file_info)
     result = raw_issue_request("GET", url, token)
 
-    for part in result["parts"]:
+    num_parts = len(result["parts"])
+    for i, part in enumerate(result["parts"]):
         upload_part(file_info, download_dest, part, token)
+        progress.progress("Uploading to Figshare", current=float((i + 1) / num_parts))
 
 
-def upload_part(file_info, stream, part, token: str):
+def upload_part(file_info, download_dest: IO, part, token: str):
     udata = file_info.copy()
     udata.update(part)
     url = "{upload_url}/{partNo}".format(**udata)
 
-    stream.seek(part["startOffset"])
-    data = stream.read(part["endOffset"] - part["startOffset"] + 1)
+    download_dest.seek(part["startOffset"])
+    data = download_dest.read(part["endOffset"] - part["startOffset"] + 1)
     raw_issue_request("PUT", url, token, data=data, binary=True)
 
 
@@ -137,16 +142,21 @@ def complete_upload(article_id: int, file_id: str, token: str):
     )
 
 
+@celery.task(bind=True)
 def upload_datafile(
+    self,
     new_article_id: int,
+    figshare_dataset_version_link_id: str,
     file_name: str,
+    datafile_id: str,
     compressed_s3_key: str,
     original_file_md5: Optional[str],
     token: str,
-) -> Union[Tuple[Literal[True], int], Tuple[Literal[False], str]]:
-    # Typing error: https://github.com/python/mypy/issues/7399
+) -> str:
+    progress = Progress(self)
     with tempfile.NamedTemporaryFile("w+b") as download_dest:
         try:
+            progress.progress("Downloading file from S3")
             file_info = initiate_new_upload(
                 new_article_id,
                 file_name,
@@ -156,16 +166,22 @@ def upload_datafile(
                 download_dest,
             )
         except HTTPError as error:
-            return False, str(error)
+            progress.failed(str(error))
+            raise error
 
         try:
-            upload_parts(download_dest, file_info, token)
+            upload_parts(download_dest, file_info, progress, token)
         except HTTPError as error:
-            return False, str(error)
+            progress.failed(str(error))
+            raise error
 
         try:
             complete_upload(new_article_id, file_info["id"], token)
         except HTTPError as error:
-            return False, str(error)
+            progress.failed(str(error))
+            raise error
 
-    return True, file_info["id"]
+    figshare_datafile_link = mc.add_figshare_datafile_link(
+        datafile_id, file_info["id"], figshare_dataset_version_link_id
+    )
+    return figshare_datafile_link.id

--- a/taiga2/figshare.py
+++ b/taiga2/figshare.py
@@ -1,0 +1,122 @@
+import hashlib
+import json
+import os
+import requests
+
+from requests.exceptions import HTTPError
+
+AUTH_URL = "https://figshare.com/account/applications/authorize{}"
+BASE_URL = "https://api.figshare.com/v2/{}"
+CHUNK_SIZE = 1024 * 1024
+
+
+def raw_issue_request(method: str, url: str, token: str, data=None, binary=False):
+    headers = {"Authorization": "token " + token}
+    if data is not None and not binary:
+        data = json.dumps(data)
+    response = requests.request(method, url, headers=headers, data=data)
+    try:
+        response.raise_for_status()
+        try:
+            data = json.loads(response.content)
+        except ValueError:
+            data = response.content
+    except HTTPError as error:
+        raise error
+
+    return data
+
+
+def issue_request(method: str, endpoint: str, token: str, *args, **kwargs):
+    return raw_issue_request(method, BASE_URL.format(endpoint), token, *args, **kwargs)
+
+
+def list_articles(token: str):
+    result = issue_request("GET", "account/articles", token)
+    print("Listing current articles:")
+    if result:
+        for item in result:
+            print(u"  {url} - {title}".format(**item))
+    else:
+        print("  No articles.")
+    print()
+
+
+def create_article(title: str, token: str):
+    data = {
+        "title": title  # You may add any other information about the article here as you wish.
+    }
+    result = issue_request("POST", "account/articles", token, data=data)
+    print("Created article:", result["location"], "\n")
+
+    result = raw_issue_request("GET", result["location"], token)
+
+    return result["id"]
+
+
+def list_files_of_article(article_id: str, token: str):
+    result = issue_request("GET", "account/articles/{}/files".format(article_id), token)
+    print("Listing files for article {}:".format(article_id))
+    if result:
+        for item in result:
+            print("  {id} - {name}".format(**item))
+    else:
+        print("  No files.")
+
+    print()
+
+
+def get_file_check_data(file_name: str):
+    with open(file_name, "rb") as fin:
+        md5 = hashlib.md5()
+        size = 0
+        data = fin.read(CHUNK_SIZE)
+        while data:
+            size += len(data)
+            md5.update(data)
+            data = fin.read(CHUNK_SIZE)
+        return md5.hexdigest(), size
+
+
+def initiate_new_upload(article_id: str, file_name: str, token: str):
+    endpoint = "account/articles/{}/files"
+    endpoint = endpoint.format(article_id)
+
+    md5, size = get_file_check_data(file_name)
+    data = {"name": os.path.basename(file_name), "md5": md5, "size": size}
+
+    result = issue_request("POST", endpoint, token, data=data)
+    print("Initiated file upload:", result["location"], "\n")
+
+    result = raw_issue_request("GET", result["location"], token)
+
+    return result
+
+
+def complete_upload(article_id: str, file_id: str, token: str):
+    issue_request(
+        "POST", "account/articles/{}/files/{}".format(article_id, file_id), token
+    )
+
+
+def upload_parts(file_path, file_info, token: str):
+    url = "{upload_url}".format(**file_info)
+    result = raw_issue_request("GET", url, token)
+
+    print("Uploading parts:")
+    with open(file_path, "rb") as fin:
+        for part in result["parts"]:
+            upload_part(file_info, fin, part, token)
+    print()
+
+
+def upload_part(file_info, stream, part, token: str):
+    udata = file_info.copy()
+    udata.update(part)
+    url = "{upload_url}/{partNo}".format(**udata)
+
+    stream.seek(part["startOffset"])
+    data = stream.read(part["endOffset"] - part["startOffset"] + 1)
+
+    raw_issue_request("PUT", url, token, data=data, binary=True)
+    print("  Uploaded part {partNo} from {startOffset} to {endOffset}".format(**part))

--- a/taiga2/figshare.py
+++ b/taiga2/figshare.py
@@ -1,9 +1,19 @@
+import boto3
+import gzip
 import hashlib
+import io
 import json
 import os
 import requests
-
+import shutil
+import tempfile
 from requests.exceptions import HTTPError
+from typing import Any, Dict, Optional, Tuple, Union
+from typing_extensions import Literal, TypedDict
+
+from flask import current_app
+
+from taiga2.aws import aws
 
 AUTH_URL = "https://figshare.com/account/applications/authorize{}"
 BASE_URL = "https://api.figshare.com/v2/{}"
@@ -31,83 +41,84 @@ def issue_request(method: str, endpoint: str, token: str, *args, **kwargs):
     return raw_issue_request(method, BASE_URL.format(endpoint), token, *args, **kwargs)
 
 
-def list_articles(token: str):
-    result = issue_request("GET", "account/articles", token)
-    print("Listing current articles:")
-    if result:
-        for item in result:
-            print(u"  {url} - {title}".format(**item))
-    else:
-        print("  No articles.")
-    print()
-
-
-def create_article(title: str, token: str):
+def validate_token(token: str, refresh_token: str) -> Tuple[str, str]:
     data = {
-        "title": title  # You may add any other information about the article here as you wish.
+        "client_id": current_app.config["FIGSHARE_CLIENT_ID"],
+        "client_secret": current_app.config["FIGSHARE_CLIENT_SECRET"],
+        "grant_type": "authorization_code",
     }
+
+    try:
+        result = issue_request("GET", "token", token, data=data)
+        return token, refresh_token
+    except HTTPError as error:
+        try:
+            data["refresh_token"] = refresh_token
+            result = issue_request("GET", "token", token, data=data)
+            return result["token"], result["refresh_token"]
+        except HTTPError as refresh_error:
+            return None, None
+
+
+def create_article(title: str, description: str, token: str):
+    data = {"title": title, "description": description}
     result = issue_request("POST", "account/articles", token, data=data)
-    print("Created article:", result["location"], "\n")
 
     result = raw_issue_request("GET", result["location"], token)
 
     return result["id"]
 
 
-def list_files_of_article(article_id: str, token: str):
-    result = issue_request("GET", "account/articles/{}/files".format(article_id), token)
-    print("Listing files for article {}:".format(article_id))
-    if result:
-        for item in result:
-            print("  {id} - {name}".format(**item))
-    else:
-        print("  No files.")
+def get_file_check_data(download_dest, compressed_s3_key: str, md5: Optional[str]):
+    s3 = aws.s3
+    bucket_name = current_app.config["S3_BUCKET"]
 
-    print()
+    compressed_s3_object = s3.Object(bucket_name, compressed_s3_key)
+    gzipped = io.BytesIO()
+
+    compressed_s3_object.download_fileobj(gzipped)
+
+    gzipped.seek(0)
+    with gzip.GzipFile(fileobj=gzipped, mode="rb") as gz:
+        shutil.copyfileobj(gz, download_dest)
+        download_dest.seek(0)
+
+        if md5 is None:
+            md5_hash = hashlib.md5()
+            data = download_dest.read(CHUNK_SIZE)
+            while data:
+                md5_hash.update(data)
+                data = download_dest.read(CHUNK_SIZE)
+            md5 = md5_hash.hexdigest()
+        s = os.path.getsize(download_dest.name)
+    return md5, s
 
 
-def get_file_check_data(file_name: str):
-    with open(file_name, "rb") as fin:
-        md5 = hashlib.md5()
-        size = 0
-        data = fin.read(CHUNK_SIZE)
-        while data:
-            size += len(data)
-            md5.update(data)
-            data = fin.read(CHUNK_SIZE)
-        return md5.hexdigest(), size
+def initiate_new_upload(
+    article_id: int,
+    file_name: str,
+    compressed_s3_key: str,
+    md5: Optional[str],
+    token: str,
+    download_dest,
+) -> Dict[str, Any]:
+    endpoint = "account/articles/{}/files".format(article_id)
 
+    md5, size = get_file_check_data(download_dest, compressed_s3_key, None)
 
-def initiate_new_upload(article_id: str, file_name: str, token: str):
-    endpoint = "account/articles/{}/files"
-    endpoint = endpoint.format(article_id)
-
-    md5, size = get_file_check_data(file_name)
-    data = {"name": os.path.basename(file_name), "md5": md5, "size": size}
+    data = {"name": file_name, "md5": md5, "size": size}
 
     result = issue_request("POST", endpoint, token, data=data)
-    print("Initiated file upload:", result["location"], "\n")
-
     result = raw_issue_request("GET", result["location"], token)
-
     return result
 
 
-def complete_upload(article_id: str, file_id: str, token: str):
-    issue_request(
-        "POST", "account/articles/{}/files/{}".format(article_id, file_id), token
-    )
-
-
-def upload_parts(file_path, file_info, token: str):
+def upload_parts(download_dest, file_info, token: str):
     url = "{upload_url}".format(**file_info)
     result = raw_issue_request("GET", url, token)
 
-    print("Uploading parts:")
-    with open(file_path, "rb") as fin:
-        for part in result["parts"]:
-            upload_part(file_info, fin, part, token)
-    print()
+    for part in result["parts"]:
+        upload_part(file_info, download_dest, part, token)
 
 
 def upload_part(file_info, stream, part, token: str):
@@ -117,6 +128,44 @@ def upload_part(file_info, stream, part, token: str):
 
     stream.seek(part["startOffset"])
     data = stream.read(part["endOffset"] - part["startOffset"] + 1)
-
     raw_issue_request("PUT", url, token, data=data, binary=True)
-    print("  Uploaded part {partNo} from {startOffset} to {endOffset}".format(**part))
+
+
+def complete_upload(article_id: int, file_id: str, token: str):
+    issue_request(
+        "POST", "account/articles/{}/files/{}".format(article_id, file_id), token
+    )
+
+
+def upload_datafile(
+    new_article_id: int,
+    file_name: str,
+    compressed_s3_key: str,
+    original_file_md5: Optional[str],
+    token: str,
+) -> Union[Tuple[Literal[True], int], Tuple[Literal[False], str]]:
+    # Typing error: https://github.com/python/mypy/issues/7399
+    with tempfile.NamedTemporaryFile("w+b") as download_dest:
+        try:
+            file_info = initiate_new_upload(
+                new_article_id,
+                file_name,
+                compressed_s3_key,
+                original_file_md5,
+                token,
+                download_dest,
+            )
+        except HTTPError as error:
+            return False, str(error)
+
+        try:
+            upload_parts(download_dest, file_info, token)
+        except HTTPError as error:
+            return False, str(error)
+
+        try:
+            complete_upload(new_article_id, file_info["id"], token)
+        except HTTPError as error:
+            return False, str(error)
+
+    return True, file_info["id"]

--- a/taiga2/models.py
+++ b/taiga2/models.py
@@ -730,6 +730,14 @@ class ThirdPartyDatasetVersionLink(db.Model):
 
     id = db.Column(GUID, primary_key=True, default=generate_uuid)
     type = db.Column(db.String(50))
+
+    creator_id = db.Column(GUID, db.ForeignKey("users.id"))
+    creator = db.relationship(
+        "User",
+        foreign_keys="ThirdPartyDatasetVersionLink.creator_id",
+        backref=__tablename__,
+    )
+
     __mapper_args__ = {"polymorphic_on": type, "polymorphic_identity": "abstract"}
 
 
@@ -743,8 +751,7 @@ class FigshareDatasetVersionLink(ThirdPartyDatasetVersionLink):
     dataset_version_id = db.Column(GUID, db.ForeignKey("dataset_versions.id"))
     dataset_version = db.relationship(
         "DatasetVersion",
-        foreign_keys="FigshareDatasetVersionLink.dataset_version_id",
-        backref=__tablename__,
+        backref=backref("figshare_dataset_version_link", uselist=False),
     )
     figshare_datafile_links = db.relationship("FigshareDataFileLink")
     __mapper_args__ = {"polymorphic_identity": "figshare"}
@@ -767,9 +774,7 @@ class FigshareDataFileLink(ThirdPartyDataFileLink):
     figshare_file_id = db.Column(db.Integer, nullable=False)
     datafile_id = db.Column(GUID, db.ForeignKey("datafiles.id"))
     datafile = db.relationship(
-        "DataFile",
-        foreign_keys="FigshareDataFileLink.datafile_id",
-        backref=__tablename__,
+        "DataFile", backref=backref("figshare_datafile_link", uselist=False)
     )
     figshare_dataset_version_link_id = db.Column(
         GUID, db.ForeignKey("figshare_dataset_version_links.id")

--- a/taiga2/models.py
+++ b/taiga2/models.py
@@ -7,6 +7,7 @@ from .extensions import metadata
 from flask_migrate import Migrate
 
 from sqlalchemy import event, UniqueConstraint, CheckConstraint
+from sqlalchemy.orm import backref
 from sqlalchemy.ext.declarative import declared_attr
 
 from typing import Dict, List
@@ -708,6 +709,20 @@ class SearchResult:
         self.current_folder = current_folder
         self.name = name
         self.entries = entries
+
+
+class FigshareAuthorization(db.Model):
+    __tablename__ = "figshare_authorizations"
+    id = db.Column(GUID, primary_key=True, default=generate_uuid)
+
+    user_id = db.Column(GUID, db.ForeignKey("users.id"))
+    user = db.relationship(
+        "User", backref=backref("figshare_authorization", uselist=False)
+    )
+
+    figshare_account_id = db.Column(db.Integer)
+    token = db.Column(db.Text, nullable=False)
+    refresh_token = db.Column(db.Text, nullable=False)
 
 
 # </editor-fold>

--- a/taiga2/models.py
+++ b/taiga2/models.py
@@ -725,4 +725,57 @@ class FigshareAuthorization(db.Model):
     refresh_token = db.Column(db.Text, nullable=False)
 
 
+class ThirdPartyDatasetVersionLink(db.Model):
+    __tablename__ = "third_party_dataset_version_links"
+
+    id = db.Column(GUID, primary_key=True, default=generate_uuid)
+    type = db.Column(db.String(50))
+    __mapper_args__ = {"polymorphic_on": type, "polymorphic_identity": "abstract"}
+
+
+class FigshareDatasetVersionLink(ThirdPartyDatasetVersionLink):
+    __tablename__ = "figshare_dataset_version_links"
+
+    id = db.Column(
+        GUID, db.ForeignKey("third_party_dataset_version_links.id"), primary_key=True
+    )
+    figshare_article_id = db.Column(db.Integer, nullable=False)
+    dataset_version_id = db.Column(GUID, db.ForeignKey("dataset_versions.id"))
+    dataset_version = db.relationship(
+        "DatasetVersion",
+        foreign_keys="FigshareDatasetVersionLink.dataset_version_id",
+        backref=__tablename__,
+    )
+    figshare_datafile_links = db.relationship("FigshareDataFileLink")
+    __mapper_args__ = {"polymorphic_identity": "figshare"}
+
+
+class ThirdPartyDataFileLink(db.Model):
+    __tablename__ = "third_party_datafile_links"
+
+    id = db.Column(GUID, primary_key=True, default=generate_uuid)
+    type = db.Column(db.String(50))
+    __mapper_args__ = {"polymorphic_on": type, "polymorphic_identity": "abstract"}
+
+
+class FigshareDataFileLink(ThirdPartyDataFileLink):
+    __tablename__ = "figshare_datafile_links"
+
+    id = db.Column(
+        GUID, db.ForeignKey("third_party_datafile_links.id"), primary_key=True
+    )
+    figshare_file_id = db.Column(db.Integer, nullable=False)
+    datafile_id = db.Column(GUID, db.ForeignKey("datafiles.id"))
+    datafile = db.relationship(
+        "DataFile",
+        foreign_keys="FigshareDataFileLink.datafile_id",
+        backref=__tablename__,
+    )
+    figshare_dataset_version_link_id = db.Column(
+        GUID, db.ForeignKey("figshare_dataset_version_links.id")
+    )
+
+    __mapper_args__ = {"polymorphic_identity": "figshare"}
+
+
 # </editor-fold>

--- a/taiga2/schemas.py
+++ b/taiga2/schemas.py
@@ -28,7 +28,19 @@ ma = Marshmallow()
 
 class UserSchema(ma.ModelSchema):
     class Meta:
-        fields = ("id", "name", "home_folder_id", "trash_folder_id", "token")
+        fields = (
+            "id",
+            "name",
+            "home_folder_id",
+            "trash_folder_id",
+            "token",
+            "figshare_linked",
+        )
+
+    figshare_linked = fields.fields.Method("check_figshare_authorization")
+
+    def check_figshare_authorization(self, user):
+        return user.figshare_authorization is not None
 
 
 class UserNamedIdSchema(ma.ModelSchema):

--- a/taiga2/schemas.py
+++ b/taiga2/schemas.py
@@ -247,6 +247,13 @@ class DataFileBaseSchema(ma.ModelSchema):
     class Meta:
         additional = ("id", "name")
 
+    figshare_file_id = fields.fields.Method("figshare_link_file_id")
+
+    def figshare_link_file_id(self, datafile):
+        if datafile.figshare_datafile_link is not None:
+            return datafile.figshare_datafile_link.figshare_file_id
+        return None
+
 
 class S3DataFileSchema(DataFileBaseSchema):
     s3_bucket = fields.fields.String()
@@ -337,6 +344,7 @@ class DatasetVersionSchema(ma.ModelSchema):
     version = fields.fields.Method("version_as_str")
     reason_state = fields.fields.Method("reason_state_str")
     description = fields.fields.Method("description_str")
+    figshare_article_id = fields.fields.Method("figshare_link_article_id")
 
     def description_str(self, dataset_version):
         if dataset_version.description is None:
@@ -365,6 +373,11 @@ class DatasetVersionSchema(ma.ModelSchema):
             return ""
         else:
             return reason_state
+
+    def figshare_link_article_id(self, dataset_version):
+        if dataset_version.figshare_dataset_version_link is not None:
+            return dataset_version.figshare_dataset_version_link.figshare_article_id
+        return None
 
 
 class DatasetFullSchema(ma.ModelSchema):

--- a/taiga2/schemas.py
+++ b/taiga2/schemas.py
@@ -245,14 +245,14 @@ class DataFileSummarySchema(ma.ModelSchema):
 
 class DataFileBaseSchema(ma.ModelSchema):
     class Meta:
-        additional = ("id", "name")
+        additional = ("id", "name", "figshare_linked")
 
-    figshare_file_id = fields.fields.Method("figshare_link_file_id")
+    figshare_linked = fields.fields.Method("figshare_link_exists")
 
-    def figshare_link_file_id(self, datafile):
+    def figshare_link_exists(self, datafile):
         if datafile.figshare_datafile_link is not None:
-            return datafile.figshare_datafile_link.figshare_file_id
-        return None
+            return True
+        return False
 
 
 class S3DataFileSchema(DataFileBaseSchema):
@@ -344,7 +344,7 @@ class DatasetVersionSchema(ma.ModelSchema):
     version = fields.fields.Method("version_as_str")
     reason_state = fields.fields.Method("reason_state_str")
     description = fields.fields.Method("description_str")
-    figshare_article_id = fields.fields.Method("figshare_link_article_id")
+    figshare_linked = fields.fields.Method("figshare_link_exists")
 
     def description_str(self, dataset_version):
         if dataset_version.description is None:
@@ -374,10 +374,10 @@ class DatasetVersionSchema(ma.ModelSchema):
         else:
             return reason_state
 
-    def figshare_link_article_id(self, dataset_version):
+    def figshare_link_exists(self, dataset_version):
         if dataset_version.figshare_dataset_version_link is not None:
-            return dataset_version.figshare_dataset_version_link.figshare_article_id
-        return None
+            return True
+        return False
 
 
 class DatasetFullSchema(ma.ModelSchema):

--- a/taiga2/swagger/swagger.yaml
+++ b/taiga2/swagger/swagger.yaml
@@ -1435,6 +1435,32 @@ paths:
         401:
           description: TODO (token does not work)
 
+  /figshare/article/{datasetVersionId}:
+    get:
+      description: Return public url for figshare article associated with dataset version
+      x-swagger-router-controller: taiga2.controllers.endpoint
+      operationId: get_figshare_public_url
+      consumes:
+        - application/json
+      parameters:
+        - name: datasetVersionId
+          in: path
+          type: string
+          description: dataset version ID
+          required: true
+      responses:
+        200:
+          description: Fig
+          schema:
+            type: object
+            required:
+              - figshare_public_url
+            properties:
+              figshare_public_url:
+                type: string
+        404:
+          description: No public article found
+
 
 definitions:
   User:
@@ -1548,10 +1574,8 @@ definitions:
         "$ref": "#/definitions/StatusEnum"
       reason_state:
         type: string
-      figshare_dataset_version_link:
-        type:
-          - string
-          - "null"
+      figshare_linked:
+        type: boolean
 
   DataFile:
     title: DataFile
@@ -1593,10 +1617,8 @@ definitions:
           - "null"
       type:
         type: string
-      figshare_link_article_id:
-        type:
-          - integer
-          - "null"
+      figshare_linked:
+        type: boolean
 
   ProvenanceEdge:
     type: object

--- a/taiga2/swagger/swagger.yaml
+++ b/taiga2/swagger/swagger.yaml
@@ -1324,6 +1324,51 @@ paths:
         404:
           description: No group with id groupId
 
+  /figshare/auth_url:
+    get:
+      description: Get the endpoint to authorize the Figshare Taiga app
+      x-swagger-router-controller: taiga2.controllers.endpoint
+      operationId: get_figshare_auth_url
+      responses:
+        200:
+          description: The Figshare endpoint
+          schema:
+            type: object
+            required:
+              - figshare_auth_url
+            properties:
+              figshare_auth_url:
+                type: string
+
+  /figshare:
+    put:
+      description: After receiving Figshare authorization code, request and save token
+      x-swagger-router-controller: taiga2.controllers.endpoint
+      operationId: add_figshare_token
+      consumes:
+        - application/json
+      parameters:
+        - name: figshareOAuthRequest
+          in: body
+          required: true
+          schema:
+            type: object
+            required:
+              - code
+              - state
+            properties:
+              code:
+                type: string
+              state:
+                type: string
+      responses:
+        200:
+          description: An existing authorization was updated
+        201:
+          description: A new authorization was created
+        400:
+          description: Figshare API request failed
+
 
 definitions:
   User:

--- a/taiga2/swagger/swagger.yaml
+++ b/taiga2/swagger/swagger.yaml
@@ -1369,6 +1369,72 @@ paths:
         400:
           description: Figshare API request failed
 
+  /figshare/link:
+    post:
+      description: Upload dataset version and files to Figshare
+      x-swagger-router-controller: taiga2.controllers.endpoint
+      operationId: upload_dataset_version_to_figshare
+      consumes:
+        - application/json
+      parameters:
+        - name: figshareDatasetVersionLink
+          in: body
+          required: true
+          schema:
+            type: object
+            required:
+              - dataset_version_id
+              - article_name
+              - files_to_upload
+            properties:
+              dataset_version_id:
+                type: string
+              article_name:
+                type: string
+              article_description:
+                type: string
+              files_to_upload:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - datafile_id
+                    - file_name
+                  properties:
+                    datafile_id:
+                      type: string
+                    file_name:
+                      type: string
+      responses:
+        200:
+          description: An existing authorization was updated
+          schema:
+            type: object
+            required:
+              - article_id
+              - files
+            properties:
+              article_id:
+                type: integer
+              files:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - datafile_id
+                    - file_name
+                  properties:
+                    datafile_id:
+                      type: string
+                    file_name:
+                      type: string
+                    figshare_file_id:
+                      type: integer
+                    failure_reason:
+                      type: string
+        401:
+          description: TODO (token does not work)
+
 
 definitions:
   User:
@@ -1380,6 +1446,7 @@ definitions:
       - home_folder_id
       - trash_folder_id
       - token
+      - figshare_linked
     properties:
       id:
         type: string
@@ -1391,6 +1458,8 @@ definitions:
         type: string
       token:
         type: string
+      figshare_linked:
+        type: boolean
 
   DatasetVersionSummary:
     title: DatasetVersionSummary

--- a/taiga2/swagger/swagger.yaml
+++ b/taiga2/swagger/swagger.yaml
@@ -1428,8 +1428,8 @@ paths:
                       type: string
                     file_name:
                       type: string
-                    figshare_file_id:
-                      type: integer
+                    task_id:
+                      type: string
                     failure_reason:
                       type: string
         401:
@@ -1548,6 +1548,10 @@ definitions:
         "$ref": "#/definitions/StatusEnum"
       reason_state:
         type: string
+      figshare_dataset_version_link:
+        type:
+          - string
+          - "null"
 
   DataFile:
     title: DataFile
@@ -1589,6 +1593,10 @@ definitions:
           - "null"
       type:
         type: string
+      figshare_link_article_id:
+        type:
+          - integer
+          - "null"
 
   ProvenanceEdge:
     type: object

--- a/taiga2/tasks.py
+++ b/taiga2/tasks.py
@@ -1,4 +1,5 @@
 from celery import Celery
+from celery.result import AsyncResult
 
 import tempfile
 import uuid
@@ -225,7 +226,7 @@ def background_process_new_upload_session_file(
 # TODO: This is only for background_process_new_upload_session_file, how to get it generic for any Celery tasks?
 def taskstatus(task_id):
     print("In task status of task_id {}".format(task_id))
-    task = background_process_new_upload_session_file.AsyncResult(task_id)
+    task = AsyncResult(task_id, app=celery)
     print("Task {}".format(task))
     print("The task is in state: {}".format(task.state))
     print("Task info is {}".format(task.info))


### PR DESCRIPTION
This adds an integration for Figshare which allows users to link a Figshare account and upload Taiga dataset versions as Figshare articles.

Users can connect their Taiga and Figshare accounts via the Taiga app owned by the shared DepMap Figshare account. We store the token and refresh token returned by Figshare's OAuth endpoint. Once connected, users can upload dataset versions and associated datafiles to a Figshare article. Datafiles must have a `compressed_s3_key`, or have underlying datafiles that have one.

Dataset versions can only be connected to one Figshare article. If a dataset version has already been uploaded to Figshare, we show a link (public url if available, private url if public is not available but the current user did the upload) to the article, or a message indicating that someone uploaded it, but it's not yet public. We also show which datafiles from the dataset version were successfully uploaded.

## Testing 

- Copy `FIGSHARE_CLIENT_ID` and `FIGSHARE_CLIENT_SECRET` from ansible-configs into `settings.cfg`.
- To connect to Figshare, go to the token page and click the link to connect to Figshare in the sidebar (you need to be logged in to the Figshare account). This will redirect back to the live Taiga site. Replace the real Taiga url with localhost.
- To upload a dataset version to Figshare, create a dataset version with datafiles that have valid `compressed_s3_keys`. Click the "Upload to Figshare" button and fill out the form.