### PR TITLE
Per file custom metadata

### DIFF
--- a/docker-base/requirements.txt
+++ b/docker-base/requirements.txt
@@ -5,6 +5,7 @@ celery==4.1.1
 certifi==2019.6.16
 Click==7.0
 clickclick==1.2.2
+openapi-spec-validator==0.2.9
 connexion[swagger-ui]==2.3.0
 docutils==0.14
 Flask==1.0.3
@@ -16,7 +17,7 @@ google-cloud-storage==1.35.0
 h5py==2.6.0
 humanize==0.5.1
 jsonpointer==2.0
-jsonschema==2.6.0
+jsonschema==2.7.0
 kombu==4.2.1
 mailjet_rest==1.3.3
 marshmallow==2.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ SQLAlchemy==1.3.0
 swagger-spec-validator==2.4.3
 typing-extensions==3.7.4.3
 Werkzeug==0.15.4
+openapi-spec-validator==0.2.9

--- a/taiga2/controllers/endpoint.py
+++ b/taiga2/controllers/endpoint.py
@@ -478,11 +478,7 @@ def create_upload_session_file(uploadMetadata, sid):
 
     # Optional per file metadata, stored as a json encoded string.
     # Not queryable independently from files.
-    custom_metadata = (
-        None
-        if "custom_metadata" not in uploadMetadata
-        else uploadMetadata["custom_metadata"]
-    )
+    custom_metadata = uploadMetadata.get("custom_metadata")
 
     if uploadMetadata["filetype"] == "s3":
         S3UploadedFileMetadata = uploadMetadata["s3Upload"]
@@ -526,13 +522,6 @@ def create_upload_session_file(uploadMetadata, sid):
                 existing_taiga_id, one_or_none=True
             )
 
-            # When adding a reference to an existing Taiga datafile, it is possible
-            # to provide a new set of custom metadata in the form of key/value pairs.
-            # If new custom_metadata is not provided, copy the key/value pairs from the
-            # original file.
-            if data_file != None and custom_metadata == None:
-                custom_metadata = data_file.custom_metadata
-
         except InvalidTaigaIdFormat as ex:
             api_error(
                 "The following was not formatted like a valid taiga ID: {}".format(
@@ -542,6 +531,13 @@ def create_upload_session_file(uploadMetadata, sid):
 
         if data_file is None:
             api_error("Unknown taiga ID: " + existing_taiga_id)
+
+        # When adding a reference to an existing Taiga datafile, it is possible
+        # to provide a new set of custom metadata in the form of key/value pairs.
+        # If new custom_metadata is not provided, copy the key/value pairs from the
+        # original file.
+        if custom_metadata == None:
+            custom_metadata = data_file.custom_metadata
 
         models_controller.add_upload_session_virtual_file(
             session_id=sid,

--- a/taiga2/controllers/models_controller.py
+++ b/taiga2/controllers/models_controller.py
@@ -1251,7 +1251,9 @@ def add_s3_datafile(
     return new_datafile
 
 
-def _add_virtual_datafile(name, datafile_id, custom_metadata):
+def _add_virtual_datafile(
+    name, datafile_id, custom_metadata: Optional[Dict[str, Any]] = None
+):
     assert isinstance(datafile_id, str)
 
     datafile = DataFile.query.get(datafile_id)
@@ -1282,8 +1284,12 @@ def _add_virtual_datafile(name, datafile_id, custom_metadata):
     return new_datafile
 
 
-def add_virtual_datafile(name, datafile_id):
-    new_datafile = _add_virtual_datafile(name=name, datafile_id=datafile_id)
+def add_virtual_datafile(
+    name, datafile_id, custom_metadata: Optional[Dict[str, Any]] = None
+):
+    new_datafile = _add_virtual_datafile(
+        name=name, datafile_id=datafile_id, custom_metadata=custom_metadata
+    )
     db.session.commit()
 
     return new_datafile

--- a/taiga2/controllers/models_controller.py
+++ b/taiga2/controllers/models_controller.py
@@ -7,7 +7,7 @@ import uuid
 import os
 import re
 
-from typing import List, Dict, Tuple, Optional
+from typing import Any, List, Dict, Tuple, Optional
 
 import json
 
@@ -1178,6 +1178,7 @@ def _add_s3_datafile(
     original_file_sha256=None,
     original_file_md5=None,
     forced_id=None,
+    custom_metadata: Optional[Dict[str, Any]] = None,
 ):
     assert type is not None
     received_type = type
@@ -1196,6 +1197,7 @@ def _add_s3_datafile(
 
     new_datafile = S3DataFile(
         name=new_datafile_name,
+        custom_metadata=custom_metadata,
         s3_bucket=s3_bucket,
         s3_key=s3_key,
         compressed_s3_key=compressed_s3_key,
@@ -1249,7 +1251,7 @@ def add_s3_datafile(
     return new_datafile
 
 
-def _add_virtual_datafile(name, datafile_id):
+def _add_virtual_datafile(name, datafile_id, custom_metadata):
     assert isinstance(datafile_id, str)
 
     datafile = DataFile.query.get(datafile_id)
@@ -1259,7 +1261,9 @@ def _add_virtual_datafile(name, datafile_id):
         datafile = datafile.underlying_data_file
 
     assert datafile.type != "virtual"
-    new_datafile = VirtualDataFile(name=name, underlying_data_file=datafile)
+    new_datafile = VirtualDataFile(
+        name=name, custom_metadata=custom_metadata, underlying_data_file=datafile
+    )
 
     db.session.add(new_datafile)
 
@@ -1285,9 +1289,12 @@ def add_virtual_datafile(name, datafile_id):
     return new_datafile
 
 
-def _add_gcs_datafile(name, gcs_path, generation_id):
+def _add_gcs_datafile(name, gcs_path, generation_id, custom_metadata):
     new_datafile = GCSObjectDataFile(
-        name=name, gcs_path=gcs_path, generation_id=generation_id
+        name=name,
+        custom_metadata=custom_metadata,
+        gcs_path=gcs_path,
+        generation_id=generation_id,
     )
 
     db.session.add(new_datafile)
@@ -1471,17 +1478,21 @@ def _add_datafiles_from_session(session_id: str):
     for file in added_files:
         if file.data_file is not None:
             new_datafile = _add_virtual_datafile(
-                name=file.filename, datafile_id=file.data_file.id
+                name=file.filename,
+                custom_metadata=file.custom_metadata,
+                datafile_id=file.data_file.id,
             )
         elif file.gcs_path is not None:
             new_datafile = _add_gcs_datafile(
                 name=file.filename,
+                custom_metadata=file.custom_metadata,
                 gcs_path=file.gcs_path,
                 generation_id=file.generation_id,
             )
         else:
             new_datafile = _add_s3_datafile(
                 name=file.filename,
+                custom_metadata=file.custom_metadata,
                 s3_bucket=file.s3_bucket,
                 s3_key=file.converted_s3_key,
                 compressed_s3_key=file.compressed_s3_key,
@@ -1620,6 +1631,7 @@ def add_upload_session_s3_file(
     initial_s3_key,
     s3_bucket,
     encoding: Optional[str],
+    custom_metadata: Optional[Dict[str, Any]] = None,
 ):
     initial_file_type = models.InitialFileType(initial_file_type)
 
@@ -1632,6 +1644,7 @@ def add_upload_session_s3_file(
     upload_session_file = UploadSessionFile(
         session_id=session_id,
         filename=filename,
+        custom_metadata=custom_metadata,
         initial_filetype=initial_file_type,
         initial_s3_key=initial_s3_key,
         s3_bucket=s3_bucket,
@@ -1640,17 +1653,27 @@ def add_upload_session_s3_file(
         compressed_s3_key=compressed_s3_key,
         encoding=encoding,
     )
+
     db.session.add(upload_session_file)
     db.session.commit()
     return upload_session_file
 
 
-def add_upload_session_virtual_file(session_id, filename, data_file_id, commit=True):
+def add_upload_session_virtual_file(
+    session_id,
+    filename,
+    data_file_id,
+    commit=True,
+    custom_metadata: Optional[Dict[str, Any]] = None,
+):
     data_file = DataFile.query.get(data_file_id)
     assert data_file is not None
 
     upload_session_file = UploadSessionFile(
-        session_id=session_id, filename=filename, data_file=data_file
+        session_id=session_id,
+        filename=filename,
+        custom_metadata=custom_metadata,
+        data_file=data_file,
     )
     db.session.add(upload_session_file)
 
@@ -1662,10 +1685,17 @@ def add_upload_session_virtual_file(session_id, filename, data_file_id, commit=T
     return upload_session_file
 
 
-def add_upload_session_gcs_file(session_id, filename, gcs_path, generation_id):
+def add_upload_session_gcs_file(
+    session_id,
+    filename,
+    gcs_path,
+    generation_id,
+    custom_metadata: Optional[Dict[str, Any]] = None,
+):
     upload_session_file = UploadSessionFile(
         session_id=session_id,
         filename=filename,
+        custom_metadata=custom_metadata,
         gcs_path=gcs_path,
         generation_id=generation_id,
     )

--- a/taiga2/models.py
+++ b/taiga2/models.py
@@ -8,7 +8,7 @@ from .extensions import metadata
 
 from flask_migrate import Migrate
 
-from sqlalchemy import event, UniqueConstraint, CheckConstraint
+from sqlalchemy import JSON, event, UniqueConstraint, CheckConstraint
 from sqlalchemy.orm import backref
 from sqlalchemy.ext.declarative import declared_attr
 
@@ -238,7 +238,9 @@ class DataFile(db.Model):
     id: str = db.Column(GUID, primary_key=True, default=generate_uuid)
     name: str = db.Column(db.String(80))
     type: str = db.Column(db.String(20))
-
+    # Calling this custom_metadata to differentiate from preset metadata, as
+    # name, type, etc are referred to as fileMetadata elsewhere in the code
+    custom_metadata = db.Column(JSON, nullable=True)
     dataset_version_id: str = db.Column(GUID, db.ForeignKey("dataset_versions.id"))
     dataset_version: "DatasetVersion" = db.relationship(
         "DatasetVersion",
@@ -601,6 +603,10 @@ class UploadSessionFile(db.Model):
 
     # filename submitted by user
     filename: str = db.Column(db.Text)
+
+    # Calling this custom_metadata to differentiate from preset metadata.
+    # custom_metadata is a json encoded dictionary.
+    custom_metadata = db.Column(JSON, nullable=True)
     encoding: str = db.Column(db.Text)
 
     initial_filetype: InitialFileType = db.Column(db.Enum(InitialFileType))

--- a/taiga2/schemas.py
+++ b/taiga2/schemas.py
@@ -251,6 +251,7 @@ class DataFileBaseSchema(ma.ModelSchema):
         additional = ("id", "name", "figshare_linked")
 
     figshare_linked = fields.fields.Method("figshare_link_exists")
+    custom_metadata = fields.fields.Dict()
 
     def figshare_link_exists(self, datafile):
         if datafile.figshare_datafile_link is not None:


### PR DESCRIPTION
Added the following changes to support uploading per file custom metadata. I call this field "custom_metadata" because metadata is a special name in SQLAlchemy.

1. Add a custom_metadata column to DataFile and UploadSessionFile.
2. When adding a reference to an existing taiga file, if key-value pairs are not provided, taiga should copy the key-value pairs from the original file.
3. Made corresponding changes to Taigapy so that custom_metadata can be uploaded via adding "custom_metadata": { "example_metadata_name": "example_metadata_value"} to any upload file type.
4. Made corresponding changes to Taigapy so that "custom_metadata" is included in the information provided for each datafile when the user calls get_dataset_metadata("example_taiga_id.version_needs_to_be_specific_to_get_datafiles_list").



I also downgraded openapi-spec-validator==0.2.9 to avoid the following issue when running Taiga locally:

> File "/Users/amourey/opt/miniconda3/envs/taiga/lib/python3.6/site-packages/openapi_spec_validator/validators.py", line 5, in <module>
    from openapi_schema_validator import OAS30Validator, oas30_format_checker
  File "/Users/amourey/opt/miniconda3/envs/taiga/lib/python3.6/site-packages/openapi_schema_validator/__init__.py", line 3, in <module>
    from openapi_schema_validator.shortcuts import validate
  File "/Users/amourey/opt/miniconda3/envs/taiga/lib/python3.6/site-packages/openapi_schema_validator/shortcuts.py", line 3, in <module>
    from openapi_schema_validator.validators import OAS30Validator
  File "/Users/amourey/opt/miniconda3/envs/taiga/lib/python3.6/site-packages/openapi_schema_validator/validators.py", line 1, in <module>
    from jsonschema import _legacy_validators, _utils, _validators
ImportError: cannot import name '_legacy_validators'