### PR TITLE
Taiga: Too easy to clobber contents of a dataset with old version

### DIFF
--- a/react_frontend/src/components/Dialogs.tsx
+++ b/react_frontend/src/components/Dialogs.tsx
@@ -91,7 +91,11 @@ export class EditName extends React.Component<EditStringProps, any> {
         onRequestClose={this.props.cancel}
         contentLabel="EditName"
       >
-        <form>
+        <form
+          onSubmit={e => {
+            formSubmitSave(this, e, this.textInput.value, null);
+          }}
+        >
           <div className="modal-content">
             <div className="modal-body">
               <div className="form-group">
@@ -115,13 +119,7 @@ export class EditName extends React.Component<EditStringProps, any> {
               >
                 Close
               </button>
-              <button
-                type="submit"
-                className="btn btn-primary"
-                onClick={(e) => {
-                  formSubmitSave(this, e, this.textInput.value, null);
-                }}
-              >
+              <button type="submit" className="btn btn-primary">
                 Save changes
               </button>
             </div>
@@ -145,7 +143,11 @@ export class EditDescription extends React.Component<EditStringProps, any> {
         onRequestClose={this.props.cancel}
         contentLabel="EditDescription"
       >
-        <form>
+        <form
+          onSubmit={e => {
+            formSubmitSave(this, e, this.textArea.value, null);
+          }}
+        >
           <div className="modal-content">
             <div className="modal-body">
               <div className="form-group">
@@ -181,13 +183,7 @@ export class EditDescription extends React.Component<EditStringProps, any> {
               >
                 Close
               </button>
-              <button
-                type="submit"
-                className="btn btn-primary"
-                onClick={(e) => {
-                  formSubmitSave(this, e, this.textArea.value, null);
-                }}
-              >
+              <button type="submit" className="btn btn-primary">
                 Save changes
               </button>
             </div>
@@ -211,7 +207,11 @@ export class CreateFolder extends React.Component<CreateFolderProps, any> {
         onRequestClose={this.props.cancel}
         contentLabel="CreateFolder"
       >
-        <form>
+        <form
+          onSubmit={e => {
+            formSubmitSave(this, e, this.textInput.value, this.textArea.value);
+          }}
+        >
           <div className="modal-content">
             <div className="modal-body">
               <div className="form-group">
@@ -246,18 +246,7 @@ export class CreateFolder extends React.Component<CreateFolderProps, any> {
               >
                 Close
               </button>
-              <button
-                type="submit"
-                className="btn btn-primary"
-                onClick={(e) => {
-                  formSubmitSave(
-                    this,
-                    e,
-                    this.textInput.value,
-                    this.textArea.value
-                  );
-                }}
-              >
+              <button type="submit" className="btn btn-primary">
                 Save changes
               </button>
             </div>
@@ -498,7 +487,12 @@ export class DeprecationReason extends React.Component<
           <div className="modal-header">
             <h2 ref="subtitle">Reason to deprecate this dataset version</h2>
           </div>
-          <form>
+          <form
+            onSubmit={e => {
+              e.preventDefault();
+              this.save();
+            }}
+          >
             <div className="modal-body">
               <input
                 type="text"
@@ -517,9 +511,9 @@ export class DeprecationReason extends React.Component<
                 Close
               </button>
               <button
-                type="button"
+                type="submit"
                 className="btn btn-primary"
-                onClick={(e) => this.save()}
+                disabled={!this.state.reason}
               >
                 Save changes
               </button>

--- a/react_frontend/src/components/dataset_view/confirm.scss
+++ b/react_frontend/src/components/dataset_view/confirm.scss
@@ -1,0 +1,34 @@
+@use "../../styles/mixins";
+
+.tableContainer {
+  min-height: 150px;
+  max-height: calc(100vh - 318px);
+  overflow: auto;
+  font-size: 16px;
+  @include mixins.scroll-shadow;
+
+  table {
+    width: 100%;
+
+    thead {
+      position: sticky;
+      top: 0;
+      background-color: #fff;
+      outline: 2px solid #ccc;
+      z-index: 1;
+    }
+
+    tr td {
+      padding: 5px;
+      border-bottom: 2px solid #eee;
+    }
+  }
+}
+
+.deprecated {
+  color: orange;
+}
+
+.deleted {
+  color: red;
+}

--- a/react_frontend/src/components/dataset_view/confirmNewVersionFromDeprecated.tsx
+++ b/react_frontend/src/components/dataset_view/confirmNewVersionFromDeprecated.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import { DatasetVersion } from "../../models/models";
+import getConfirmation from "../../utilities/getConfirmation";
+
+function confirmNewVersionFromDeprecated(datasetVersion: DatasetVersion) {
+  const { state } = datasetVersion;
+
+  return getConfirmation({
+    title: "Are you sure?",
+    message: (
+      <div>
+        <p>
+          This version is {state === "deprecated" ? "deprecated" : "deleted"}.
+          Are you sure you want to create a new version based on it?
+        </p>
+      </div>
+    ),
+    noText: "Cancel",
+    yesText: "Create new version",
+    yesButtonBsStyle: "warning",
+  });
+}
+
+export default confirmNewVersionFromDeprecated;

--- a/react_frontend/src/components/dataset_view/confirmUserWantsToBranchVersion.tsx
+++ b/react_frontend/src/components/dataset_view/confirmUserWantsToBranchVersion.tsx
@@ -1,0 +1,96 @@
+import * as React from "react";
+import { Dataset, DatasetVersion } from "../../models/models";
+import { relativePath } from "../../utilities/route";
+import getConfirmation from "../../utilities/getConfirmation";
+import styles from "./confirm.scss";
+
+function confirmUserWantsToBranchVersion(
+  dataset: Dataset,
+  datasetVersion: DatasetVersion
+) {
+  const thisVersion = Number(datasetVersion.version);
+  const newerVersions = dataset.versions.slice(thisVersion);
+  const permaname = dataset.permanames.slice(-1)[0];
+
+  return getConfirmation({
+    title: "Are you sure?",
+    message: (
+      <div>
+        <p>
+          This is not the latest version. If you create a new version based on
+          this one,
+          <br />
+          it could be missing important files that were added later.
+        </p>
+        <p>
+          {newerVersions.length === 1
+            ? "This newer verision already exists:"
+            : "These newer versions already exist:"}
+        </p>
+        <VersionList permaname={permaname} newerVersions={newerVersions} />
+      </div>
+    ),
+    noText: "Cancel",
+    yesText: "Use this version anyway",
+    yesButtonBsStyle: "warning",
+  });
+}
+
+const Icon = ({ className }: { className: string }) => (
+  <>
+    <i className={`glyphicon ${className}`} />{" "}
+  </>
+);
+
+function VersionList({
+  newerVersions,
+  permaname,
+}: {
+  newerVersions: Dataset["versions"];
+  permaname: string;
+}) {
+  return (
+    <div className={styles.tableContainer}>
+      <table>
+        <thead>
+          <tr>
+            <th>Version</th>
+            <th />
+            <th>Link</th>
+          </tr>
+        </thead>
+        <tbody>
+          {newerVersions.map(version => (
+            <tr key={version.id}>
+              <td>{version.name}</td>
+              <td>
+                {version.state === "deprecated" && (
+                  <span className={styles.deprecated}>
+                    <Icon className="glyphicon-warning-sign" />
+                    Deprecated
+                  </span>
+                )}
+                {version.state === "deleted" && (
+                  <span className={styles.deleted}>
+                    <Icon className="glyphicon-exclamation-sign" />
+                    Deleted
+                  </span>
+                )}
+              </td>
+              <td>
+                <a
+                  target="_blank"
+                  href={relativePath(`/dataset/${permaname}/${version.name}`)}
+                >
+                  View <Icon className="glyphicon-new-window" />
+                </a>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default confirmUserWantsToBranchVersion;

--- a/react_frontend/src/components/modals/UploadDialogs/types.ts
+++ b/react_frontend/src/components/modals/UploadDialogs/types.ts
@@ -42,4 +42,5 @@ export interface CreateVersionDialogProps extends DialogProps {
     params: CreateVersionParams | CreateDatasetParams,
     uploadProgressCallback: (status: Array<UploadStatus>) => void
   ): Promise<any>;
+  checkConcurrentEdit(): Promise<boolean>;
 }

--- a/react_frontend/src/models/models.ts
+++ b/react_frontend/src/models/models.ts
@@ -181,7 +181,7 @@ export interface DatasetVersionDatafiles {
 export interface DatasetVersions {
   name: string;
   id: string;
-  status: StatusEnum;
+  state: StatusEnum;
 }
 
 export class Dataset extends Entry {

--- a/react_frontend/src/styles/utilities.scss
+++ b/react_frontend/src/styles/utilities.scss
@@ -1,0 +1,29 @@
+.confirmationHeader {
+  h4 {
+    font-size: 16px;
+  }
+}
+
+.confirmationBody {
+  font-size: 15px;
+  padding-bottom: 10px;
+}
+
+.dontShowThisAgain {
+  position: relative;
+  top: 20px;
+  font-size: 13px;
+
+  label {
+    font-weight: normal;
+    cursor: pointer;
+    margin: 0;
+    line-height: 22px;
+  }
+
+  span {
+    margin: 5px;
+    vertical-align: top;
+  }
+}
+

--- a/react_frontend/src/utilities/getConfirmation.tsx
+++ b/react_frontend/src/utilities/getConfirmation.tsx
@@ -1,0 +1,111 @@
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import { Button, Modal } from "react-bootstrap";
+import styles from "../styles/utilities.scss";
+
+interface ConfirmationOptions {
+  title?: string | null;
+  yesText?: string | null;
+  noText?: string | null;
+  message: React.ReactNode;
+  showModalBackdrop?: boolean | null;
+  yesButtonBsStyle?: string | null | undefined;
+  dontShowAgainLocalStorageKey?: string;
+}
+
+const launchModal = (
+  options: ConfirmationOptions,
+  resolve: (ok: boolean) => void
+) => {
+  if (options.dontShowAgainLocalStorageKey) {
+    const skip =
+      window.localStorage.getItem(options.dontShowAgainLocalStorageKey!) ===
+      "true";
+
+    if (skip) {
+      resolve(true);
+      return;
+    }
+  }
+
+  const container = document.createElement("div");
+  container.id = "confirmation-modal-container";
+  document.body.append(container);
+
+  const unmount = () => {
+    ReactDOM.unmountComponentAtNode(container);
+    container.remove();
+  };
+
+  ReactDOM.render(
+    <Modal
+      show
+      backdrop={
+        typeof options.showModalBackdrop === "boolean"
+          ? options.showModalBackdrop
+          : true
+      }
+      onHide={() => {
+        resolve(false);
+        unmount();
+      }}
+    >
+      <Modal.Header className={styles.confirmationHeader}>
+        <Modal.Title>{options.title || "Are you sure?"}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body className={styles.confirmationBody}>
+        <section>{options.message}</section>
+        {options.dontShowAgainLocalStorageKey && (
+          <section className={styles.dontShowThisAgain}>
+            <label>
+              <input
+                type="checkbox"
+                defaultChecked={false}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  if (e.target.checked) {
+                    window.localStorage.setItem(
+                      options.dontShowAgainLocalStorageKey!,
+                      "true"
+                    );
+                  } else {
+                    window.localStorage.removeItem(
+                      options.dontShowAgainLocalStorageKey!
+                    );
+                  }
+                }}
+              />
+              <span>Don’t show this again</span>
+            </label>
+          </section>
+        )}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button
+          onClick={() => {
+            resolve(false);
+            unmount();
+          }}
+        >
+          {options.noText || "No"}
+        </Button>
+        <Button
+          bsStyle={options.yesButtonBsStyle || "danger"}
+          onClick={() => {
+            resolve(true);
+            unmount();
+          }}
+        >
+          {options.yesText || "Yes"}
+        </Button>
+      </Modal.Footer>
+    </Modal>,
+
+    container
+  );
+};
+
+export default function getConfirmation(options: ConfirmationOptions) {
+  return new Promise<boolean>((resolve) => {
+    launchModal(options, resolve);
+  });
+}

--- a/react_frontend/src/utilities/showInfoModal.tsx
+++ b/react_frontend/src/utilities/showInfoModal.tsx
@@ -1,0 +1,63 @@
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import { Button, Modal } from "react-bootstrap";
+
+type ModalProps = React.ComponentProps<typeof Modal>;
+type ModalPropsWithOptionalOnHide = Omit<ModalProps, "onHide"> & {
+  onHide?: ModalProps["onHide"];
+};
+
+interface InfoModalOptions {
+  title: string;
+  content: React.ReactNode;
+  closeButtonText?: string;
+  modalProps?: ModalPropsWithOptionalOnHide;
+}
+
+function showInfoModal(
+  options: InfoModalOptions
+): Promise<void> {
+  const container = document.createElement("div");
+  container.id = "confirmation-modal-container";
+  document.body.append(container);
+
+  let resolveFn: () => void;
+
+  const promise = new Promise<void>((resolve) => {
+    resolveFn = resolve;
+  });
+
+  const unmount = () => {
+    ReactDOM.unmountComponentAtNode(container);
+    container.remove();
+    resolveFn();
+  };
+
+  ReactDOM.render(
+    <Modal
+      backdrop="static"
+      {...options.modalProps}
+      show
+      onHide={() => {
+        options.modalProps?.onHide?.();
+        unmount();
+      }}
+    >
+      <Modal.Header>
+        <Modal.Title>{options.title}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <section>{options.content}</section>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button onClick={unmount}>{options.closeButtonText || "Close"}</Button>
+      </Modal.Footer>
+    </Modal>,
+
+    container
+  );
+
+  return promise;
+}
+
+export default  showInfoModal;


### PR DESCRIPTION
This adds warnings in all of the following scenarios:

- Creating a new version based on a version older than latest
- Creating a new version based on a deprecated or deleted version
- Attempting to upload a version that is no longer the latest
  - While the first two are checked as soon as you click "create new version," this one is checked at upload time. It warns only if a new version has been created at some point after the page was loaded.