### PR TITLE
Follow-up to "Include dataset name in page title"

### DIFF
--- a/react_frontend/src/components/FolderView.tsx
+++ b/react_frontend/src/components/FolderView.tsx
@@ -50,6 +50,7 @@ export interface FolderViewState {
   folder?: Folder.Folder;
   datasetLastDatasetVersion?: { [dataset_id: string]: Folder.DatasetVersion };
   datasetsVersion?: { [datasetVersion_id: string]: Folder.DatasetVersion };
+  allDatasets?: DatasetFullDatasetVersions[];
 
   showEditName?: boolean;
   showEditDescription?: boolean;
@@ -158,6 +159,7 @@ export class FolderView extends React.Component<
     let _folder: Folder.Folder = null;
 
     const request = ++this.lastRequestNumber;
+    let allDatasets: DatasetFullDatasetVersions[] = [];
 
     return tapi
       .get_folder(this.props.match.params.folderId)
@@ -199,6 +201,8 @@ export class FolderView extends React.Component<
         return tapi
           .get_datasets(datasetIds)
           .then((arrayDatasets: Array<DatasetFullDatasetVersions>) => {
+            allDatasets = arrayDatasets;
+
             arrayDatasets.forEach((dataset: DatasetFullDatasetVersions) => {
               // We get the latest datasetVersion
               let latestDatasetVersion: DatasetVersion = dataset.versions[0];
@@ -229,6 +233,7 @@ export class FolderView extends React.Component<
           selection: new Array<string>(),
           datasetLastDatasetVersion: datasetsLatestDv,
           datasetsVersion: datasetsVersion,
+          allDatasets,
           loading: false,
         });
       })
@@ -646,10 +651,12 @@ export class FolderView extends React.Component<
           ];
           let full_datasetVersion: Folder.DatasetVersion = this.state
             .datasetsVersion[entry.id];
+
           return new BootstrapTableFolderEntry(
             entry,
             latestDatasetVersion,
-            full_datasetVersion
+            full_datasetVersion,
+            this.state.allDatasets,
           );
         }
       );

--- a/react_frontend/src/components/GroupListView.tsx
+++ b/react_frontend/src/components/GroupListView.tsx
@@ -22,6 +22,10 @@ export class GroupListView extends React.Component<
   GroupListProps,
   GroupListState
 > {
+  componentDidMount() {
+    document.title = "My Groups - Taiga";
+  }
+
   groupLinkFormatter(
     cell: string,
     row: Pick<Group, Exclude<keyof Group, "users">>

--- a/react_frontend/src/components/GroupView.tsx
+++ b/react_frontend/src/components/GroupView.tsx
@@ -49,7 +49,13 @@ export class GroupView extends React.Component<GroupViewProps, GroupViewState> {
   }
 
   componentDidMount() {
-    this.doFetch().then(() => {
+    document.title = "My Groups - Taiga";
+
+    this.doFetch().then(group => {
+      if (group) {
+        document.title = `My Groups - ${group.name} - Taiga`;
+      }
+
       this.props.tapi.get_all_users().then((r: Array<User>) => {
         this.setState({ allUsers: r });
       });
@@ -58,7 +64,12 @@ export class GroupView extends React.Component<GroupViewProps, GroupViewState> {
 
   componentDidUpdate(prevProps: GroupViewProps) {
     if (prevProps.match.params.groupId != this.props.match.params.groupId) {
-      this.doFetch();
+      this.doFetch()
+        .then(group => {
+          if (group) {
+            document.title = `My Groups - ${group.name} - Taiga`;
+          }
+        });
     }
   }
 
@@ -67,6 +78,7 @@ export class GroupView extends React.Component<GroupViewProps, GroupViewState> {
       .get_group(this.props.match.params.groupId)
       .then((r: Group) => {
         this.setState({ group: r, errorMessage: null });
+        return r;
       })
       .catch((err: Error) => {
         this.setState({ errorMessage: err.message });

--- a/react_frontend/src/components/NotFound.tsx
+++ b/react_frontend/src/components/NotFound.tsx
@@ -1,23 +1,14 @@
 import * as React from "react";
-// import { Link } from 'react-router';
-// import * as update from 'immutability-helper';
-
-// import { LeftNav, MenuItem } from "./LeftNav";
-// import * as Folder from "../models/models";
-// import { TaigaApi } from "../models/api";
-
-// import * as Dialogs from "./Dialogs";
-// import { TreeView } from "./modals/TreeView";
-
-// import { toLocalDateString } from "../utilities/formats";
-// import { relativePath } from "../utilities/route";
-// import { LoadingOverlay } from "../utilities/loading";
 
 interface NotFoundProps {
   message?: string;
 }
 
 export class NotFound extends React.Component<NotFoundProps, any> {
+  componentDidMount() {
+    document.title = "Not Found - Taiga";
+  }
+
   render() {
     return (
       <div className="notFound">

--- a/react_frontend/src/components/RecentlyViewed.tsx
+++ b/react_frontend/src/components/RecentlyViewed.tsx
@@ -38,6 +38,7 @@ export class RecentlyViewed extends React.Component<
   }
 
   componentDidMount() {
+    document.title = "Recently Viewed - Taiga";
     this.doFetch();
   }
 

--- a/react_frontend/src/components/SearchView.tsx
+++ b/react_frontend/src/components/SearchView.tsx
@@ -93,6 +93,8 @@ export class SearchView extends React.Component<
   componentDidUpdate(prevProps: SearchViewProps) {}
 
   componentDidMount() {
+    document.title = "Search Results - Taiga";
+
     // this.doFetch().then(() => {
     //     this.logAccess();
     // });

--- a/react_frontend/src/components/Token.tsx
+++ b/react_frontend/src/components/Token.tsx
@@ -37,6 +37,7 @@ export class Token extends React.Component<TokenProps, TokenState> {
   }
 
   componentDidMount() {
+    document.title = "My Token - Taiga";
     this.doFetch();
   }
 

--- a/react_frontend/src/models/models.ts
+++ b/react_frontend/src/models/models.ts
@@ -319,13 +319,41 @@ export class BootstrapTableFolderEntry {
   url: string;
   creation_date: Date;
   creator_name: string;
-
   type: FolderEntriesTypeEnum;
+
+  constructor(
+    entry: FolderEntries,
+    latestDatasetVersion?: DatasetVersion,
+    fullDatasetVersion?: DatasetVersion,
+    allDatasets?: DatasetFullDatasetVersions[]
+  ) {
+    this.id = entry.id;
+    this.name = entry.name;
+
+    this.url = this.processFolderEntryUrl(
+      entry,
+      latestDatasetVersion,
+      fullDatasetVersion,
+      allDatasets
+    );
+
+    this.creation_date = this.processCreationDate(entry, latestDatasetVersion);
+
+    // TODO: Think about what to do with an entry without a user
+    if (entry.creator && entry.creator.name) {
+      this.creator_name = entry.creator.name;
+    } else {
+      this.creator_name = undefined;
+    }
+
+    this.type = entry.type;
+  }
 
   processFolderEntryUrl(
     entry: FolderEntries,
     latestDatasetVersion?: DatasetVersion,
-    full_datasetVersion?: DatasetVersion
+    full_datasetVersion?: DatasetVersion,
+    allDatasets?: DatasetFullDatasetVersions[]
   ) {
     let processedUrl = null;
     if (entry.type === FolderEntriesTypeEnum.Folder) {
@@ -338,9 +366,18 @@ export class BootstrapTableFolderEntry {
       entry.type === FolderEntriesTypeEnum.Dataset ||
       entry.type === FolderEntriesTypeEnum.VirtualDataset
     ) {
-      processedUrl = relativePath(
-        "dataset/" + entry.id + "/" + latestDatasetVersion.id
-      );
+      const dataset = (allDatasets || []).find(d => d.id === entry.id);
+      const permaname = dataset.permanames.slice(-1)[0];
+
+      if (dataset) {
+        processedUrl = relativePath(
+          `/dataset/${permaname}/${latestDatasetVersion.name}`
+        );
+      } else {
+        processedUrl = relativePath(
+          "dataset/" + entry.id + "/" + latestDatasetVersion.id
+        );
+      }
     }
 
     return processedUrl;
@@ -363,32 +400,6 @@ export class BootstrapTableFolderEntry {
     }
 
     return processedCreationDate;
-  }
-
-  constructor(
-    entry: FolderEntries,
-    latestDatasetVersion?: DatasetVersion,
-    fullDatasetVersion?: DatasetVersion
-  ) {
-    this.id = entry.id;
-    this.name = entry.name;
-
-    this.url = this.processFolderEntryUrl(
-      entry,
-      latestDatasetVersion,
-      fullDatasetVersion
-    );
-
-    this.creation_date = this.processCreationDate(entry, latestDatasetVersion);
-
-    // TODO: Think about what to do with an entry without a user
-    if (entry.creator && entry.creator.name) {
-      this.creator_name = entry.creator.name;
-    } else {
-      this.creator_name = undefined;
-    }
-
-    this.type = entry.type;
   }
 }
 


### PR DESCRIPTION
- Make sure all ancillary pages get a title (e.g. "Recently Viewed")
- Prevent duplicate history entries
  - This would happen when a link like "/dataset/:id" would redirect to "/dataset/:permaname/:version"
    - Now the folder view uses the latter format directly