### PR TITLE
Fix raw files UI 26q1

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,23 @@ See deployment for notes on how to deploy the project on a live system (Coming s
 
 ## Running Locally
 
-Start these four processes in separate terminal windows:
+### One command (recommended)
+
+```bash
+./dev.sh
+```
+
+This single script handles everything:
+
+- Starts **Redis** (if not already running)
+- Starts **MiniStack** Docker container for local S3 (if `settings.cfg` is configured for it)
+- Creates the **S3 bucket** and **dev database** if they don't exist
+- Launches the **Webpack dev server**, **Flask app**, and **Celery worker** as background processes
+- **Ctrl+C** stops all services cleanly
+
+Open your browser to: **http://127.0.0.1:5000/taiga/**
+
+### Manual (if you prefer separate terminals)
 
 ```bash
 # Terminal 1 — Redis (skip if already running; check with `redis-cli ping`)
@@ -62,6 +78,8 @@ poetry run bash -c 'source setup_env.sh && flask run-worker'
 ```
 
 Open your browser to: **http://127.0.0.1:5000/taiga/**
+
+### Notes
 
 You are automatically logged in as the seeded admin user (`admin@broadinstitute.org`) via the `DEFAULT_USER_EMAIL` setting.
 
@@ -200,9 +218,16 @@ INSERT INTO group_user_association (group_id, user_id) select 1, id FROM users W
 
 ## Running the tests
 
-Install rhdf5 R library => http://bioconductor.org/packages/release/bioc/html/rhdf5.html
+```bash
+# Run all tests
+poetry run pytest
 
-`pytest` from the root
+# Run a specific test file
+poetry run pytest taiga2/tests/datafile_test.py
+
+# Run with verbose output (shows each test name)
+poetry run pytest -v
+```
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -51,13 +51,16 @@ See deployment for notes on how to deploy the project on a live system (Coming s
 ./dev.sh
 ```
 
-This single script handles everything:
+This single script handles setup and launches all services via [mprocs](https://github.com/pvolok/mprocs):
 
 - Starts **Redis** (if not already running)
 - Starts **MiniStack** Docker container for local S3 (if `settings.cfg` is configured for it)
 - Creates the **S3 bucket** and **dev database** if they don't exist
-- Launches the **Webpack dev server**, **Flask app**, and **Celery worker** as background processes
-- **Ctrl+C** stops all services cleanly
+- Launches the **Webpack dev server**, **Flask app**, and **Celery worker** via mprocs
+
+mprocs gives you a TUI where you can switch between process outputs with `j`/`k`, restart individual processes with `r`, and quit everything with `q`.
+
+**Prerequisite:** Install mprocs with `brew install mprocs`
 
 Open your browser to: **http://127.0.0.1:5000/taiga/**
 

--- a/dev.sh
+++ b/dev.sh
@@ -1,25 +1,11 @@
 #!/usr/bin/env bash
-# Start all Taiga services for local development with one command.
+# Start all Taiga services for local development.
+# Runs setup (Redis, MiniStack, DB) then launches mprocs.
 # Usage: ./dev.sh
 set -e
 
 export FLASK_APP='autoapp.py'
 export FLASK_DEBUG=1
-
-PIDS=()
-
-cleanup() {
-    echo ""
-    echo "Shutting down..."
-    for pid in "${PIDS[@]}"; do
-        kill "$pid" 2>/dev/null
-    done
-    for pid in "${PIDS[@]}"; do
-        wait "$pid" 2>/dev/null
-    done
-    echo "Done."
-}
-trap cleanup EXIT INT TERM
 
 # --- Redis ---
 if redis-cli ping &>/dev/null; then
@@ -67,24 +53,9 @@ else
     echo "[ok] Dev database exists (instance/db.sqlite3)"
 fi
 
-# --- Start services ---
+# --- Launch all services via mprocs ---
 echo ""
-echo "Starting Taiga services..."
-
-poetry run flask webpack &
-PIDS+=($!)
-
-poetry run flask run &
-PIDS+=($!)
-
-poetry run flask run-worker &
-PIDS+=($!)
-
+echo "Starting Taiga services with mprocs..."
+echo "  http://127.0.0.1:5000/taiga/"
 echo ""
-echo "  Webpack dev server  http://127.0.0.1:5001"
-echo "  Flask app server    http://127.0.0.1:5000/taiga/"
-echo "  Celery worker       (background)"
-echo ""
-echo "Press Ctrl+C to stop all services."
-
-wait
+exec mprocs --config mprocs.yaml

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Start all Taiga services for local development with one command.
+# Usage: ./dev.sh
+set -e
+
+export FLASK_APP='autoapp.py'
+export FLASK_DEBUG=1
+
+PIDS=()
+
+cleanup() {
+    echo ""
+    echo "Shutting down..."
+    for pid in "${PIDS[@]}"; do
+        kill "$pid" 2>/dev/null
+    done
+    for pid in "${PIDS[@]}"; do
+        wait "$pid" 2>/dev/null
+    done
+    echo "Done."
+}
+trap cleanup EXIT INT TERM
+
+# --- Redis ---
+if redis-cli ping &>/dev/null; then
+    echo "[ok] Redis already running"
+else
+    echo "[..] Starting Redis..."
+    redis-server --daemonize yes
+    echo "[ok] Redis started"
+fi
+
+# --- MiniStack (if settings.cfg is configured for it) ---
+if grep -q "^S3_ENDPOINT_URL = 'http://localhost:4566'" settings.cfg 2>/dev/null; then
+    if docker ps --format '{{.Names}}' | grep -q '^ministack$'; then
+        echo "[ok] MiniStack already running"
+    elif docker ps -a --format '{{.Names}}' | grep -q '^ministack$'; then
+        echo "[..] Starting MiniStack..."
+        docker start ministack >/dev/null
+        echo "[ok] MiniStack started"
+    else
+        echo "[..] Starting MiniStack (first time — pulling image)..."
+        docker run -d --name ministack -p 4566:4566 nahuelnucera/ministack >/dev/null
+        sleep 3
+        echo "[ok] MiniStack started"
+    fi
+
+    poetry run python -c "
+import boto3
+s3 = boto3.client('s3', endpoint_url='http://localhost:4566',
+                  aws_access_key_id='test', aws_secret_access_key='test')
+try:
+    s3.head_bucket(Bucket='taiga-dev')
+    print('[ok] taiga-dev S3 bucket exists')
+except Exception:
+    s3.create_bucket(Bucket='taiga-dev')
+    print('[ok] Created taiga-dev S3 bucket')
+" 2>/dev/null
+fi
+
+# --- Dev database ---
+if [ ! -f instance/db.sqlite3 ]; then
+    echo "[..] Creating dev database..."
+    poetry run flask recreate-dev-db
+    echo "[ok] Dev database created"
+else
+    echo "[ok] Dev database exists (instance/db.sqlite3)"
+fi
+
+# --- Start services ---
+echo ""
+echo "Starting Taiga services..."
+
+poetry run flask webpack &
+PIDS+=($!)
+
+poetry run flask run &
+PIDS+=($!)
+
+poetry run flask run-worker &
+PIDS+=($!)
+
+echo ""
+echo "  Webpack dev server  http://127.0.0.1:5001"
+echo "  Flask app server    http://127.0.0.1:5000/taiga/"
+echo "  Celery worker       (background)"
+echo ""
+echo "Press Ctrl+C to stop all services."
+
+wait

--- a/dev.sh
+++ b/dev.sh
@@ -3,9 +3,7 @@
 # Runs setup (Redis, MiniStack, DB) then launches mprocs.
 # Usage: ./dev.sh
 set -e
-
-export FLASK_APP='autoapp.py'
-export FLASK_DEBUG=1
+source setup_env.sh
 
 # --- Redis ---
 if redis-cli ping &>/dev/null; then
@@ -53,9 +51,4 @@ else
     echo "[ok] Dev database exists (instance/db.sqlite3)"
 fi
 
-# --- Launch all services via mprocs ---
-echo ""
-echo "Starting Taiga services with mprocs..."
-echo "  http://127.0.0.1:5000/taiga/"
-echo ""
 exec mprocs --config mprocs.yaml

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -1,0 +1,7 @@
+procs:
+  webpack:
+    shell: "source setup_env.sh && poetry run flask webpack"
+  flask:
+    shell: "source setup_env.sh && poetry run flask run"
+  worker:
+    shell: "source setup_env.sh && poetry run flask run-worker"

--- a/react_frontend/src/models/models.ts
+++ b/react_frontend/src/models/models.ts
@@ -176,6 +176,7 @@ export interface DatasetVersionDatafiles {
   gcs_path: string;
   original_file_md5?: string;
   original_file_sha256?: string;
+  custom_metadata?: Record<string, string>;
 }
 
 export interface DatasetVersions {

--- a/taiga2/controllers/endpoint.py
+++ b/taiga2/controllers/endpoint.py
@@ -762,6 +762,12 @@ def task_status(taskStatusId):
 
 
 def _no_transform_needed(requested_format, datafile_type, custom_metadata=None):
+    assert isinstance(requested_format, str), (
+        f"Expected requested_format to be a string, got {type(requested_format)}"
+    )
+    assert isinstance(datafile_type, S3DataFile.DataFileFormat), (
+        f"Expected datafile_type to be a DataFileFormat enum, got {type(datafile_type)}"
+    )
     if (
         requested_format == conversion.RAW_FORMAT
         and datafile_type == S3DataFile.DataFileFormat.Raw
@@ -781,8 +787,8 @@ def _no_transform_needed(requested_format, datafile_type, custom_metadata=None):
         return True
 
     if datafile_type == S3DataFile.DataFileFormat.Raw:
-        resolved = conversion.resolve_raw_storage_format(custom_metadata)
-        if resolved and requested_format == resolved:
+        detected_format = conversion.resolve_raw_storage_format(custom_metadata)
+        if detected_format and requested_format == detected_format:
             return True
 
     return False

--- a/taiga2/controllers/endpoint.py
+++ b/taiga2/controllers/endpoint.py
@@ -761,7 +761,7 @@ def task_status(taskStatusId):
     return flask.jsonify(status)
 
 
-def _no_transform_needed(requested_format, datafile_type):
+def _no_transform_needed(requested_format, datafile_type, custom_metadata=None):
     if (
         requested_format == conversion.RAW_FORMAT
         and datafile_type == S3DataFile.DataFileFormat.Raw
@@ -779,6 +779,16 @@ def _no_transform_needed(requested_format, datafile_type):
         and datafile_type == S3DataFile.DataFileFormat.Columnar
     ):
         return True
+
+    if datafile_type == S3DataFile.DataFileFormat.Raw and custom_metadata:
+        csf = custom_metadata.get("client_storage_format")
+        if requested_format == conversion.HDF5_FORMAT and csf == "raw_hdf5_matrix":
+            return True
+        if (
+            requested_format == conversion.PARQUET_FORMAT
+            and csf == "raw_parquet_table"
+        ):
+            return True
 
     return False
 
@@ -862,7 +872,7 @@ def _get_s3_datafile(
     if format == "metadata":
         urls = None
         conversion_status = "Completed successfully"
-    elif _no_transform_needed(format, real_datafile.format):
+    elif _no_transform_needed(format, real_datafile.format, real_datafile.custom_metadata):
         # no conversion is necessary
         urls = [
             create_signed_get_obj(

--- a/taiga2/controllers/endpoint.py
+++ b/taiga2/controllers/endpoint.py
@@ -780,14 +780,9 @@ def _no_transform_needed(requested_format, datafile_type, custom_metadata=None):
     ):
         return True
 
-    if datafile_type == S3DataFile.DataFileFormat.Raw and custom_metadata:
-        csf = custom_metadata.get("client_storage_format")
-        if requested_format == conversion.HDF5_FORMAT and csf == "raw_hdf5_matrix":
-            return True
-        if (
-            requested_format == conversion.PARQUET_FORMAT
-            and csf == "raw_parquet_table"
-        ):
+    if datafile_type == S3DataFile.DataFileFormat.Raw:
+        resolved = conversion.resolve_raw_storage_format(custom_metadata)
+        if resolved and requested_format == resolved:
             return True
 
     return False

--- a/taiga2/conv/__init__.py
+++ b/taiga2/conv/__init__.py
@@ -38,3 +38,18 @@ COMPRESSED_FORMAT = "raw_test"
 HDF5_FORMAT = "hdf5"
 COLUMNAR_FORMAT = "columnar"
 PARQUET_FORMAT = "parquet"
+
+# Maps taigapy client_storage_format values to the actual download format.
+# Used to resolve the real format of Raw S3DataFiles that contain known binary types.
+RAW_STORAGE_FORMAT_MAP = {
+    "raw_hdf5_matrix": HDF5_FORMAT,
+    "raw_parquet_table": PARQUET_FORMAT,
+}
+
+
+def resolve_raw_storage_format(custom_metadata):
+    """Return the actual download format for a Raw datafile, or None if unknown."""
+    if custom_metadata:
+        csf = custom_metadata.get("client_storage_format")
+        return RAW_STORAGE_FORMAT_MAP.get(csf)
+    return None

--- a/taiga2/conv/__init__.py
+++ b/taiga2/conv/__init__.py
@@ -37,3 +37,4 @@ COMPRESSED_FORMAT = "raw_test"
 # Canonical format
 HDF5_FORMAT = "hdf5"
 COLUMNAR_FORMAT = "columnar"
+PARQUET_FORMAT = "parquet"

--- a/taiga2/conv/__init__.py
+++ b/taiga2/conv/__init__.py
@@ -48,8 +48,12 @@ RAW_STORAGE_FORMAT_MAP = {
 
 
 def resolve_raw_storage_format(custom_metadata):
-    """Return the actual download format for a Raw datafile, or None if unknown."""
+    """Return the actual download format for a Raw datafile, or None if unknown.
+    """
     if custom_metadata:
+        assert isinstance(custom_metadata, dict), (
+            f"custom_metadata must be a dict, got {type(custom_metadata)}"
+        )
         csf = custom_metadata.get("client_storage_format")
         return RAW_STORAGE_FORMAT_MAP.get(csf)
     return None

--- a/taiga2/create_test_db_sqlalchemy.py
+++ b/taiga2/create_test_db_sqlalchemy.py
@@ -160,6 +160,87 @@ def create_db_and_populate():
     # create a sample dataset in a known location with a known permaname
     create_sample_dataset(forced_permaname="sample-1", folder_id="public")
 
+    # Create a dataset that demonstrates all file format labels
+    create_format_examples_dataset(folder_id="public")
+
+
+def create_format_examples_dataset(folder_id):
+    """Create a dataset with files of every format type to verify download labels."""
+    from taiga2.models import db
+
+    parquet_file = models_controller.add_s3_datafile(
+        name="gene_expression",
+        s3_bucket=bucket_name,
+        s3_key=models_controller.generate_convert_key(),
+        compressed_s3_key=None,
+        type=models.S3DataFile.DataFileFormat.Raw,
+        encoding="UTF-8",
+        short_summary="Parquet table uploaded via taigapy v3",
+        long_summary="",
+    )
+    parquet_file.custom_metadata = {"client_storage_format": "raw_parquet_table"}
+
+    hdf5_raw_file = models_controller.add_s3_datafile(
+        name="cell_viability",
+        s3_bucket=bucket_name,
+        s3_key=models_controller.generate_convert_key(),
+        compressed_s3_key=None,
+        type=models.S3DataFile.DataFileFormat.Raw,
+        encoding="UTF-8",
+        short_summary="HDF5 matrix uploaded via taigapy v3",
+        long_summary="",
+    )
+    hdf5_raw_file.custom_metadata = {"client_storage_format": "raw_hdf5_matrix"}
+
+    raw_file = models_controller.add_s3_datafile(
+        name="model_weights",
+        s3_bucket=bucket_name,
+        s3_key=models_controller.generate_convert_key(),
+        compressed_s3_key=None,
+        type=models.S3DataFile.DataFileFormat.Raw,
+        encoding="UTF-8",
+        short_summary="Opaque binary file",
+        long_summary="",
+    )
+
+    matrix_file = models_controller.add_s3_datafile(
+        name="crispr_scores",
+        s3_bucket=bucket_name,
+        s3_key=models_controller.generate_convert_key(),
+        compressed_s3_key=None,
+        type=models.S3DataFile.DataFileFormat.HDF5,
+        encoding="UTF-8",
+        short_summary="Numeric matrix (server-converted to HDF5)",
+        long_summary="",
+    )
+
+    table_file = models_controller.add_s3_datafile(
+        name="sample_metadata",
+        s3_bucket=bucket_name,
+        s3_key=models_controller.generate_convert_key(),
+        compressed_s3_key=None,
+        type=models.S3DataFile.DataFileFormat.Columnar,
+        encoding="UTF-8",
+        short_summary="Table (server-converted to Columnar)",
+        long_summary="",
+    )
+
+    db.session.flush()
+
+    ds = models_controller.add_dataset(
+        name="Format Examples",
+        permaname=models.generate_permaname("Format Examples"),
+        description="Dataset with one file per format type — use to verify download labels and code snippets",
+        datafiles_ids=[
+            parquet_file.id,
+            hdf5_raw_file.id,
+            raw_file.id,
+            matrix_file.id,
+            table_file.id,
+        ],
+    )
+    models_controller.add_folder_entry(folder_id, ds.id)
+
 
 def recreate_dev_db():
     database_uri = current_app.config["SQLALCHEMY_DATABASE_URI"]

--- a/taiga2/models.py
+++ b/taiga2/models.py
@@ -392,12 +392,9 @@ def get_allowed_conversion_type(datafile: S3DataFile) -> List[str]:
         return allowed_conversion_types
 
     if datafile.format == S3DataFile.DataFileFormat.Raw:
-        if datafile.custom_metadata:
-            csf = datafile.custom_metadata.get("client_storage_format")
-            if csf == "raw_hdf5_matrix":
-                return [conversion.HDF5_FORMAT]
-            elif csf == "raw_parquet_table":
-                return [conversion.PARQUET_FORMAT]
+        resolved = conversion.resolve_raw_storage_format(datafile.custom_metadata)
+        if resolved:
+            return [resolved]
         return [conversion.RAW_FORMAT]
 
     raise Exception(

--- a/taiga2/models.py
+++ b/taiga2/models.py
@@ -392,9 +392,9 @@ def get_allowed_conversion_type(datafile: S3DataFile) -> List[str]:
         return allowed_conversion_types
 
     if datafile.format == S3DataFile.DataFileFormat.Raw:
-        resolved = conversion.resolve_raw_storage_format(datafile.custom_metadata)
-        if resolved:
-            return [resolved]
+        detected_format = conversion.resolve_raw_storage_format(datafile.custom_metadata)
+        if detected_format:
+            return [detected_format]
         return [conversion.RAW_FORMAT]
 
     raise Exception(

--- a/taiga2/models.py
+++ b/taiga2/models.py
@@ -392,6 +392,12 @@ def get_allowed_conversion_type(datafile: S3DataFile) -> List[str]:
         return allowed_conversion_types
 
     if datafile.format == S3DataFile.DataFileFormat.Raw:
+        if datafile.custom_metadata:
+            csf = datafile.custom_metadata.get("client_storage_format")
+            if csf == "raw_hdf5_matrix":
+                return [conversion.HDF5_FORMAT]
+            elif csf == "raw_parquet_table":
+                return [conversion.PARQUET_FORMAT]
         return [conversion.RAW_FORMAT]
 
     raise Exception(

--- a/taiga2/tests/datafile_test.py
+++ b/taiga2/tests/datafile_test.py
@@ -194,3 +194,29 @@ def test_find_datafile(session, db, user_id):
 
     # using dataset version id and dataset name
     assert find_datafile(None, None, dataset_version_id, "invalid") is None
+
+
+@pytest.mark.parametrize(
+    "client_storage_format, expected_conversion_types",
+    [
+        ("raw_hdf5_matrix", ["hdf5"]),
+        ("raw_parquet_table", ["parquet"]),
+    ],
+)
+def test_raw_files_with_known_format_get_proper_conversion_type(
+    session, db, user_id, client_storage_format, expected_conversion_types
+):
+    df = mc.add_s3_datafile(
+        name="testfile",
+        s3_bucket="bucket",
+        s3_key="key",
+        compressed_s3_key=None,
+        type=models.S3DataFile.DataFileFormat.Raw,
+        encoding="UTF-8",
+        short_summary="short",
+        long_summary="long",
+    )
+    df.custom_metadata = {"client_storage_format": client_storage_format}
+    db.session.commit()
+
+    assert models.get_allowed_conversion_type(df) == expected_conversion_types


### PR DESCRIPTION
This PR primarily resolves the issue mentioned in asana task [here](https://app.asana.com/1/9513920295503/project/1201928954496973/task/1207152912752466), Taiga: when user uses v3 client, uploaded parquet/hdf5 files are shown as "raw" on UI, primarily. There are some secondary changes too. Overall: 

1. Files uploaded as HDF5 or Parquet via taigapy v3 now correctly shows "hdf5" or "parquet" instead of "raw" in the UI, and downloaded files get proper extensions (.hdf5, .parquet). 
2. As a side benefit, this also fixes the Python code snippet at the bottom of dataset pages. Parquet/HDF5 files now shows tc.get() instead of tc.download_to_cache(). This was a request from Simone couple of days ago. 
3. Added a dev.sh + mprocs.yaml for one-command local development (./dev.sh handles Redis, MiniStack, DB creation, then launches all services via mprocs). Updated README. 
4. Added a "Format Examples" dataset to recreate-dev-db with one file per format type (parquet, hdf5, raw, HDF5 matrix, Columnar table) for easy visual verification of download labels.

<img width="1271" height="773" alt="Screenshot 2026-04-13 at 11 17 16 AM" src="https://github.com/user-attachments/assets/d209f8b1-c43d-4301-b048-74cb8210c24d" />
